### PR TITLE
:memo: Add documentation for public functions and objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 path = "src/lib.rs"
 
 [[bin]]
-name = "fmaas-orchestr8"
+name = "fms-orchestr8"
 path = "src/main.rs"
 
 [dependencies]

--- a/TODOs.md
+++ b/TODOs.md
@@ -6,6 +6,6 @@
 - [ ] Add unit tests
 - [ ] Add request validation for classification with text generation endpoint
 - [ ] Add request validation for streaming classification with text generation endpoint
-- [ ] Host API in swagger pages in the reo
+- [ ] Host API in swagger pages in the repo
 - [ ] Tokenization REST API and client will need to be updated for bidirectional streaming if/when available for REST use
 - [ ] There is currently NO WAY for us to know the prefix ID required by TGIS for inferencing on tuned prompts

--- a/src/clients/nlp.rs
+++ b/src/clients/nlp.rs
@@ -34,6 +34,7 @@ pub struct NlpServicer {
 }
 
 impl NlpServicer {
+    /// Create a new NLP client
     pub async fn new(
         default_target_port: u16,
         client_tls: Option<&ClientTlsConfig>,
@@ -90,7 +91,7 @@ impl NlpService for NlpServicer {
         request: Request<Streaming<BidiStreamingTokenizationTaskRequest>>,
     ) -> Result<Response<Self::BidiStreamingTokenizationTaskPredictStream>, Status> {
         let model_id = extract_model_id(&request)?;
-        let br = request.get_ref();
+        let _br = request.get_ref();
         // TODO: Empty case should look different for streaming
         debug!(
             "Performing bidirectional streaming tokenization task predict request for Model ID {}",

--- a/src/clients/tgis.rs
+++ b/src/clients/tgis.rs
@@ -17,6 +17,7 @@ pub struct GenerationServicer {
 }
 
 impl GenerationServicer {
+    /// Create a new text generation client
     pub async fn new(
         default_target_port: u16,
         client_tls: Option<&ClientTlsConfig>,
@@ -55,7 +56,7 @@ impl GenerationService for GenerationServicer {
         }
         debug!("Routing generation request for Model ID {}", &br.model_id);
         let mut client = self.client(&br.model_id).await?;
-        let mut span = tracing::info_span!(
+        let _span = tracing::info_span!(
             "fmaas.GenerationService/Generate",
             rpc.system = "grpc",
             rpc.method = "Generate",
@@ -85,7 +86,7 @@ impl GenerationService for GenerationServicer {
             &sr.model_id
         );
         let mut client = self.client(&sr.model_id).await?;
-        let mut span = tracing::info_span!(
+        let _span = tracing::info_span!(
             "fmaas.GenerationService/GenerateStream",
             rpc.system = "grpc",
             rpc.method = "GenerateStream",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
 // Module for defining structure for detector map config and its utilities
 
 use std::{collections::HashMap, path::Path};
-use anyhow::Context;
-use futures::future::try_join_all;
+
+
 
 use serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 use anyhow::Context;
 use futures::future::try_join_all;
 use ginepro::LoadBalancedChannel;
-use tokio::try_join;
-use std::{collections::HashMap, path::Path};
+
+use std::{collections::HashMap};
 use tonic::transport::ClientTlsConfig;
 
 use serde::{Serialize, Deserialize};

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,20 +1,25 @@
 #![allow(unused_qualifications)]
 
-use validator::Validate;
 
 
+/// User request to orchestrator
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct GuardrailsHttpRequest {
+    /// Text generation model ID
     #[serde(rename = "model_id")]
     pub model_id: String,
 
+    /// User prompt/input text to a text generation model
     #[serde(rename = "inputs")]
     pub inputs: String,
 
+    /// Configuration of guardrails models for either or both input to a text generation model
+    /// (e.g. user prompt) and output of a text generation model
     #[serde(rename = "guardrail_config")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub guardrail_config: Option<GuardrailsConfig>,
 
+    /// Parameters for text generation
     #[serde(rename = "text_gen_parameters")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub text_gen_parameters: Option<GuardrailsTextGenerationParameters>,
@@ -22,6 +27,7 @@ pub struct GuardrailsHttpRequest {
 }
 
 impl GuardrailsHttpRequest {
+    /// Creates a user request with text generation model ID and input text
     #[allow(clippy::new_without_default)]
     pub fn new(model_id: String, inputs: String, ) -> GuardrailsHttpRequest {
         GuardrailsHttpRequest {
@@ -33,158 +39,219 @@ impl GuardrailsHttpRequest {
     }
 }
 
+/// Configuration of guardrails models for either or both input to a text generation model
+/// (e.g. user prompt) and output of a text generation model
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct GuardrailsConfig {
+    /// Configuration for detection on input to a text generation model (e.g. user prompt)
     #[serde(rename = "input")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input: Option<GuardrailsConfigInput>,
 
+    /// Configuration for detection on output of a text generation model
     #[serde(rename = "output")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub output: Option<GuardrailsConfigOutput>,
 
 }
 
+/// Configuration for detection on input to a text generation model (e.g. user prompt)
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct GuardrailsConfigInput {
+    /// Map of model name to model specific parameters
     #[serde(rename = "models")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub models: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
 
+    /// Vector of spans are in the form of (span_start, span_end) corresponding
+    /// to spans of input text on which to run input detection
     #[serde(rename = "masks")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub masks: Option<Vec<(usize, usize)>>
 }
 
+/// Configuration for detection on output of a text generation model
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct GuardrailsConfigOutput {
+    /// Map of model name to model specific parameters
     #[serde(rename = "models")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub models: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
 }
 
+/// Parameters for text generation, ref. <https://github.com/IBM/text-generation-inference/blob/main/proto/generation.proto>
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct GuardrailsTextGenerationParameters {
+    /// Maximum number of new tokens to generate
     #[serde(rename = "max_new_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub max_new_tokens: Option<i32>,
 
+    /// Minimum number of new tokens to generate
     #[serde(rename = "min_new_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub min_new_tokens: Option<i32>,
 
+    /// Truncate to this many input tokens for generation
     #[serde(rename = "truncate_input_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub truncate_input_tokens: Option<i32>,
 
+    /// The high level decoding strategy for picking
+    /// tokens during text generation
     #[serde(rename = "decoding_method")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub decoding_method: Option<String>,
 
+    /// Number of highest probability vocabulary tokens to keep for top-k-filtering.
+    /// Only applies for sampling mode. When decoding_strategy is set to sample,
+    /// only the top_k most likely tokens are considered as candidates for the next generated token.
     #[serde(rename = "top_k")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub top_k: Option<i32>,
 
+    /// Similar to top_k except the candidates to generate the next token are the
+    /// most likely tokens with probabilities that add up to at least top_p.
+    /// Also known as nucleus sampling. A value of 1.0 is equivalent to disabled.
     #[serde(rename = "top_p")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub top_p: Option<f64>,
 
+    /// Local typicality measures how similar the conditional probability of
+    /// predicting a target token next is to the expected conditional
+    /// probability of predicting a random token next, given the partial text
+    /// already generated
     #[serde(rename = "typical_p")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub typical_p: Option<f64>,
 
+    /// A value used to modify the next-token probabilities in sampling mode.
+    /// Values less than 1.0 sharpen the probability distribution, resulting in
+    /// "less random" output. Values greater than 1.0 flatten the probability distribution,
+    /// resulting in "more random" output. A value of 1.0 has no effect.
     #[serde(rename = "temperature")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub temperature: Option<f64>,
 
+    /// Represents the penalty for penalizing tokens that have already been generated
+    /// or belong to the context. The value 1.0 means that there is no penalty.
     #[serde(rename = "repetition_penalty")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub repetition_penalty: Option<f64>,
 
+    /// Time limit in milliseconds for text generation to complete
     #[serde(rename = "max_time")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub max_time: Option<f64>,
 
+    /// Parameters to exponentially increase the likelihood of the text generation
+    /// terminating once a specified number of tokens have been generated.
     #[serde(rename = "exponential_decay_length_penalty")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub exponential_decay_length_penalty: Option<ExponentialDecayLengthPenalty>,
 
+    /// One or more strings which will cause the text generation to stop if/when
+    /// they are produced as part of the output.
     #[serde(rename = "stop_sequences")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub stop_sequences: Option<Vec<String>>,
 
+    /// Random seed used for text generation
     #[serde(rename = "seed")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub seed: Option<i32>,
 
+    /// Whether or not to include input text
     #[serde(rename = "preserve_input_text")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub preserve_input_text: Option<bool>,
 
+    /// Whether or not to include input text
     #[serde(rename = "input_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input_tokens: Option<bool>,
 
+    /// Whether or not to include list of individual generated tokens
     #[serde(rename = "generated_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_tokens: Option<bool>,
 
+    /// Whether or not to include logprob for each returned token
+    /// Applicable only if generated_tokens == true and/or input_tokens == true
     #[serde(rename = "token_logprobs")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token_logprobs: Option<bool>,
 
+    /// Whether or not to include rank of each returned token
+    /// Applicable only if generated_tokens == true and/or input_tokens == true
     #[serde(rename = "token_ranks")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token_ranks: Option<bool>,
 
 }
 
+/// Parameters to exponentially increase the likelihood of the text generation
+/// terminating once a specified number of tokens have been generated.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct ExponentialDecayLengthPenalty {
+    /// Start the decay after this number of tokens have been generated
     #[serde(rename = "start_index")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub start_index: Option<i32>,
 
+    /// Factor of exponential decay
     #[serde(rename = "decay_factor")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub decay_factor: Option<f64>,
 
 }
 
-
+/// Classification result on text produced by a text generation model, containing
+/// information from the original text generation output as well as the result of
+/// classification on the generated text.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ClassifiedGeneratedTextResult {
+    /// Generated text
     #[serde(rename = "generated_text")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_text: Option<String>,
 
+    /// Classification results for input to text generation model and/or
+    /// output from the text generation model
     #[serde(rename = "token_classification_results")]
     pub token_classification_results: TextGenTokenClassificationResults,
 
+    /// Why text generation stopped
     #[serde(rename = "finish_reason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub finish_reason: Option<FinishReason>,
 
+    /// Length of sequence of generated tokens
     #[serde(rename = "generated_token_count")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_token_count: Option<i32>,
 
+    /// Random seed used for text generation
     #[serde(rename = "seed")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub seed: Option<i32>,
 
+    /// Length of input
     #[serde(rename = "input_token_count")]
     pub input_token_count: i32,
 
+    /// Vector of warnings on input detection
     #[serde(rename = "warnings")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub warnings: Option<Vec<InputWarning>>,
 
+    /// Individual generated tokens and associated details, if requested
     #[serde(rename = "tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tokens: Option<Vec<GeneratedToken>>,
 
+    /// Input tokens and associated details, if requested
     #[serde(rename = "input_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input_tokens: Option<Vec<GeneratedToken>>,
@@ -193,6 +260,8 @@ pub struct ClassifiedGeneratedTextResult {
 
 
 impl ClassifiedGeneratedTextResult {
+    /// Creates a classification result on text produced by a text generation model
+    /// with given token classification results and token count
     #[allow(clippy::new_without_default)]
     pub fn new(token_classification_results: TextGenTokenClassificationResults, input_token_count: i32, ) -> ClassifiedGeneratedTextResult {
         ClassifiedGeneratedTextResult {
@@ -209,6 +278,9 @@ impl ClassifiedGeneratedTextResult {
     }
 }
 
+/// Streaming classification result on text produced by a text generation model, containing
+/// information from the original text generation output as well as the result of
+/// classification on the generated text. Also indicates where in stream is processed.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ClassifiedGeneratedTextStreamResult {
@@ -216,46 +288,59 @@ pub struct ClassifiedGeneratedTextStreamResult {
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_text: Option<String>,
 
+    /// Classification results for input to text generation model and/or
+    /// output from the text generation model
     #[serde(rename = "token_classification_results")]
     pub token_classification_results: TextGenTokenClassificationResults,
 
+    /// Why text generation stopped
     #[serde(rename = "finish_reason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub finish_reason: Option<FinishReason>,
 
+    /// Length of sequence of generated tokens
     #[serde(rename = "generated_token_count")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_token_count: Option<i32>,
 
+    /// Random seed used for text generation
     #[serde(rename = "seed")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub seed: Option<i32>,
 
+    /// Length of input
     #[serde(rename = "input_token_count")]
     pub input_token_count: i32,
 
+    /// Vector of warnings on input detection
     #[serde(rename = "warnings")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub warnings: Option<Vec<InputWarning>>,
 
+    /// Individual generated tokens and associated details, if requested
     #[serde(rename = "tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tokens: Option<Vec<GeneratedToken>>,
 
+    /// Input tokens and associated details, if requested
     #[serde(rename = "input_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input_tokens: Option<Vec<GeneratedToken>>,
 
+    /// Result index up to which text is processed
     #[serde(rename = "processed_index")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub processed_index: Option<i32>,
 
+    /// Result start index for processed text
     #[serde(rename = "start_index")]
     pub start_index: i32,
 
 }
 
 impl ClassifiedGeneratedTextStreamResult {
+    /// Creates a stream classification result on text produced by a text generation model
+    /// with given token classification results and token count and starting stream index
     #[allow(clippy::new_without_default)]
     pub fn new(token_classification_results: TextGenTokenClassificationResults, input_token_count: i32, start_index: i32, ) -> ClassifiedGeneratedTextStreamResult {
         ClassifiedGeneratedTextStreamResult {
@@ -274,13 +359,17 @@ impl ClassifiedGeneratedTextStreamResult {
     }
 }
 
+/// Results of classification on input to a text generation model (e.g. user prompt)
+/// or output of a text generation model
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct TextGenTokenClassificationResults {
+    /// Classification results on input to a text generation model
     #[serde(rename = "input")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input: Option<Vec<TokenClassificationResult>>,
 
+    /// Classification results on output from a text generation model
     #[serde(rename = "output")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub output: Option<Vec<TokenClassificationResult>>,
@@ -289,6 +378,8 @@ pub struct TextGenTokenClassificationResults {
 
 
 impl TextGenTokenClassificationResults {
+    /// Creates results of classification on input to a text generation model (e.g. user prompt)
+    /// and/or output of a text generation model
     #[allow(clippy::new_without_default)]
     pub fn new() -> TextGenTokenClassificationResults {
         TextGenTokenClassificationResults {
@@ -298,33 +389,46 @@ impl TextGenTokenClassificationResults {
     }
 }
 
+/// Single token classification result
+/// NOTE: This is meant to align with the HuggingFace token classification task:
+/// <https://huggingface.co/docs/transformers/tasks/token_classification#inference>
+/// The field `word` does not necessarily correspond to a single "word",
+/// and `entity` may not always be applicable beyond "entity" in the NER
+/// (named entity recognition) sense
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 pub struct TokenClassificationResult {
+    /// Beginning/start offset of token
     #[serde(rename = "start")]
     pub start: i32,
 
+    /// End offset of token
     #[serde(rename = "end")]
     pub end: i32,
 
+    /// Text referenced by token
     #[serde(rename = "word")]
     pub word: String,
 
+    /// Predicted relevant class name for the token
     #[serde(rename = "entity")]
     pub entity: String,
 
+    /// Aggregate label, if applicable
     #[serde(rename = "entity_group")]
     pub entity_group: String,
 
+    /// Confidence-like score of this classification prediction in [0, 1]
     #[serde(rename = "score")]
     pub score: f64,
 
+    /// Length of tokens in the text
     #[serde(rename = "token_count")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub token_count: Option<i32>,
 
 }
 
-/// Enumeration of values.
+/// Enumeration of reasons why text generation stopped
 /// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
 /// which helps with FFI.
 #[allow(non_camel_case_types)]
@@ -350,20 +454,23 @@ pub enum FinishReason {
     Error,
 }
 
+/// Warning reason and message on input detection
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct InputWarning {
+    /// Warning reason
     #[serde(rename = "id")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<InputWarningReason>,
 
+    /// Warning message
     #[serde(rename = "message")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 
 }
 
-/// Enumeration of values.
+/// Enumeration of warning reasons on input detection
 /// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
 /// which helps with FFI.
 #[allow(non_camel_case_types)]
@@ -371,94 +478,123 @@ pub struct InputWarning {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum InputWarningReason {
+    /// Unsuitable text detected on input
     #[serde(rename = "UNSUITABLE_INPUT")]
     UnsuitableInput,
 }
 
+/// Generated token information
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct GeneratedToken {
+    /// Token text
     #[serde(rename = "text")]
     pub text: String,
 
+    /// Logprob (log of normalized probability)
     #[serde(rename = "logprob")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub logprob: Option<f64>,
 
+    /// One-based rank relative to other tokens
     #[serde(rename = "rank")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub rank: Option<i32>,
 
 }
 
+/// Result of a text generation model
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct GeneratedTextResult {
+    /// Generated text
     #[serde(rename = "generated_text")]
     pub generated_text: String,
 
+    /// Length of sequence of generated tokens
     #[serde(rename = "generated_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_tokens: Option<i32>,
 
+    /// Why text generation stopped
     #[serde(rename = "finish_reason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub finish_reason: Option<FinishReason>,
 
+    /// Length of input
     #[serde(rename = "input_token_count")]
     pub input_token_count: i32,
 
+    /// Random seed used for text generation
     #[serde(rename = "seed")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub seed: Option<i32>,
 
+    /// Individual generated tokens and associated details, if requested
     #[serde(rename = "tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tokens: Option<Vec<GeneratedToken>>,
 
+    /// Input tokens and associated details, if requested
     #[serde(rename = "input_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input_tokens: Option<Vec<GeneratedToken>>,
 }
 
+/// Details on the streaming result of a text generation model
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct TokenStreamDetails {
+    /// Why text generation stopped
     #[serde(rename = "finish_reason")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub finish_reason: Option<FinishReason>,
 
+    /// Length of sequence of generated tokens
     #[serde(rename = "generated_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub generated_tokens: Option<i32>,
 
+    /// Random seed used for text generation
     #[serde(rename = "seed")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub seed: Option<i32>,
 
+    /// Length of input
     #[serde(rename = "input_token_count")]
     pub input_token_count: i32,
 }
 
+/// Streaming result of a text generation model
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct GeneratedTextStreamResult {
+    /// Generated text
     #[serde(rename = "generated_text")]
     pub generated_text: String,
 
+    /// Individual generated tokens and associated details, if requested
     #[serde(rename = "tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tokens: Option<Vec<GeneratedToken>>,
 
+    /// Details on the streaming result of a text generation model
     #[serde(rename = "details")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub details: Option<TokenStreamDetails>,
 
+    /// Streaming result of a text generation model
     #[serde(rename = "input_tokens")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub input_tokens: Option<Vec<GeneratedToken>>,
 }
 
+
+// TODO: The below errors follow FastAPI concepts esp. for loc
+// It may be worth revisiting if the orchestrator without FastAPI
+// should be using these error types
+
+/// HTTP validation error
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct HttpValidationError {
@@ -468,15 +604,18 @@ pub struct HttpValidationError {
 
 }
 
+/// Validation error
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ValidationError {
     #[serde(rename = "loc")]
     pub loc: Vec<LocationInner>,
 
+    /// Error message
     #[serde(rename = "msg")]
     pub msg: String,
 
+    /// Error type
     #[serde(rename = "type")]
     pub r#type: String,
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,7 @@
 use crate::{
-    clients::{nlp::NlpServicer, tgis::{self, GenerationServicer}},
-    config::{self, OrchestratorConfig},
+    clients::{nlp::NlpServicer},
+    config::{self},
     models,
-    pb::{caikit_data_model::nlp::TokenClassificationResults, fmaas::generation_service_server::GenerationService},
     utils,
     ErrorResponse,
     GuardrailsResponse};
@@ -10,19 +9,15 @@ use crate::{
 
 use core::panic;
 use std::{net::SocketAddr, sync::Arc};
-use async_stream::try_stream;
+
 use axum::{
-    error_handling::HandleError,
-    error_handling::future::HandleErrorFuture, extract::{Extension, State}, http::{response, HeaderMap, Method, StatusCode}, response::IntoResponse, routing::{get, post}, Json, Router
+    extract::State, http::StatusCode, response::IntoResponse, routing::{get, post}, Json, Router
 };
 // sse -> server side events
-use axum_macros::debug_handler;
 use axum::response::sse::{Event, KeepAlive, Sse};
-use futures::{stream::{self, Stream}, FutureExt, StreamExt, TryStreamExt};
-use serde::{Serialize};
-use serde_json::{json, Value};
-use tokio::{signal};
-use tokio_stream::wrappers;
+use futures::stream::Stream;
+use serde::Serialize;
+use tokio::signal;
 use tracing::info;
 use std::convert::Infallible;
 
@@ -51,13 +46,14 @@ const DUMMY_RESPONSE: [&'static str; 9] = ["This", "is", "very", "good", "news,"
 // ========================================== Handler functions ==========================================
 
 
-// Server shared state
+/// Server shared state
 #[derive(Clone)]
 pub(crate) struct ServerState {
     // pub tgis_servicer: GenerationServicer,
     pub caikit_nlp_servicer: NlpServicer
 }
 
+/// Run the orchestrator server
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     rest_addr: SocketAddr,
@@ -110,8 +106,8 @@ async fn health() -> Result<(), ()> {
 // #[debug_handler]
 // TODO: Improve Bad Request error handling by implementing Validate middleware
 async fn classification_with_generation(
-    State(state): State<Arc<ServerState>>,
-    Json(payload): Json<models::GuardrailsHttpRequest>) -> Json<GuardrailsResponse> {
+    State(_state): State<Arc<ServerState>>,
+    Json(_payload): Json<models::GuardrailsHttpRequest>) -> Json<GuardrailsResponse> {
 
     // TODO: note this function currently is not doing .await and hence is blocking
     let token_class_result = models::TextGenTokenClassificationResults::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,7 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 
 use axum::{
-    http::StatusCode,
-    response::{IntoResponse, sse::{Event, KeepAlive}},
+    response::{sse::{Event}},
     Json,
 };
 use futures::{stream::Stream, StreamExt};
@@ -13,9 +12,9 @@ use tonic::transport::{
     Certificate, ClientTlsConfig,
 };
 use tokio::fs::read;
-use tracing::{error, info};
+use tracing::{error};
 
-use crate::{models, ErrorResponse, GuardrailsResponse};
+use crate::{models, ErrorResponse};
 use crate::{
     clients::tgis::GenerationServicer,
     clients::nlp::{NlpServicer, METADATA_NAME_MODEL_ID}
@@ -38,10 +37,9 @@ use crate::pb::caikit_data_model::nlp::{
 };
 
 
-
-
 // =========================================== Client Calls ==============================================
 
+/// Configures the text generation (TGIS) client
 pub async fn configure_tgis(
     service_addr: ServiceAddr,
     default_target_port: u16,
@@ -63,13 +61,14 @@ pub async fn configure_tgis(
     generation_servicer.await
 }
 
+/// Calls server streaming text generation through the TGIS client
 pub async fn call_tgis_stream(
     Json(payload): Json<models::GuardrailsHttpRequest>,
     tgis_servicer: GenerationServicer,
     on_message_callback: impl Fn(models::ClassifiedGeneratedTextStreamResult) -> Event,
 )  -> impl Stream<Item = Result<Event, Infallible>> {
     // TODO: Add remaining parameter
-    let mut tgis_request = tonic::Request::new(
+    let tgis_request = tonic::Request::new(
         SingleGenerationRequest {
             model_id: payload.model_id,
             request: Some(GenerationRequest {text: payload.inputs}),
@@ -115,7 +114,7 @@ pub async fn call_tgis_stream(
 }
 
 
-
+/// Configures the NLP client
 pub async fn configure_nlp(
     service_addr: ServiceAddr,
     default_target_port: u16,
@@ -137,6 +136,7 @@ pub async fn configure_nlp(
     nlp_servicer.await
 }
 
+/// Calls server streaming text generation through the NLP client
 pub async fn call_nlp_text_gen_stream (
     Json(payload): Json<models::GuardrailsHttpRequest>,
     nlp_servicer: NlpServicer,
@@ -197,11 +197,11 @@ pub async fn call_nlp_text_gen_stream (
     stream
 }
 
-
+/// Calls a given detector through the NLP token classification API
 pub async fn call_nlp_token_classification (
     text: String,
     model_id: String,
-    params: Option<HashMap<String, Box<dyn std::any::Any>>>,
+    _params: Option<HashMap<String, Box<dyn std::any::Any>>>,
     nlp_servicer: NlpServicer,
 ) -> Result<TokenClassificationResults, ErrorResponse> {
 
@@ -228,6 +228,7 @@ pub async fn call_nlp_token_classification (
     }
 }
 
+/// Calls a given chunker through the NLP tokenization API
 pub async fn call_chunker(
     text: String,
     model_id: String,


### PR DESCRIPTION
- Change bin to `fms-orchestr8` to match package name
- Mainly document structs in `src/models.rs` - left a TODO here to revisit the error objects since they appear to be from FastAPI currently
- Some unused import removals
- `orchestrator.rs` will likely become internal/non-public and to avoid conflicting PRs, this is not touched in this PR

To see docs:
- `cargo docs`
-  Command will show where docs are visible, if not, navigate to `fms_orchestr8/all.html`