### PR TITLE
:sparkles: Chunkers client

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .include_file("mod.rs")
         .compile(
             &[
+                "protos/caikit_runtime_Chunkers.proto",
                 "protos/caikit_runtime_Nlp.proto",
                 "protos/generation.proto",
                 "protos/caikit_data_model_caikit_nlp.proto",

--- a/protos/caikit_runtime_Chunkers.proto
+++ b/protos/caikit_runtime_Chunkers.proto
@@ -1,0 +1,31 @@
+
+/*------------------------------------------------------------------------------
+ * AUTO GENERATED
+ *----------------------------------------------------------------------------*/
+
+syntax = "proto3";
+package caikit.runtime.Chunkers;
+import "caikit_data_model_nlp.proto";
+
+
+/*-- MESSAGES ----------------------------------------------------------------*/
+
+message BidiStreamingTokenizationTaskRequest {
+
+  /*-- fields --*/
+  string text_stream = 1;
+}
+
+message TokenizationTaskRequest {
+
+  /*-- fields --*/
+  string text = 1;
+}
+
+
+/*-- SERVICES ----------------------------------------------------------------*/
+
+service ChunkersService {
+  rpc BidiStreamingTokenizationTaskPredict(stream caikit.runtime.Chunkers.BidiStreamingTokenizationTaskRequest) returns (stream caikit_data_model.nlp.TokenizationStreamResult);
+  rpc TokenizationTaskPredict(caikit.runtime.Chunkers.TokenizationTaskRequest) returns (caikit_data_model.nlp.TokenizationResults);
+}

--- a/protos/caikit_runtime_Nlp.proto
+++ b/protos/caikit_runtime_Nlp.proto
@@ -83,7 +83,6 @@
  /*-- SERVICES ----------------------------------------------------------------*/
 
  service NlpService {
-   rpc BidiStreamingTokenizationTaskPredict(stream caikit.runtime.Nlp.BidiStreamingTokenizationTaskRequest) returns (stream caikit_data_model.nlp.TokenizationStreamResult);
    rpc ServerStreamingTextGenerationTaskPredict(caikit.runtime.Nlp.ServerStreamingTextGenerationTaskRequest) returns (stream caikit_data_model.nlp.GeneratedTextStreamResult);
    rpc TextGenerationTaskPredict(caikit.runtime.Nlp.TextGenerationTaskRequest) returns (caikit_data_model.nlp.GeneratedTextResult);
    rpc TokenizationTaskPredict(caikit.runtime.Nlp.TokenizationTaskRequest) returns (caikit_data_model.nlp.TokenizationResults);

--- a/protos/caikit_runtime_Nlp.proto
+++ b/protos/caikit_runtime_Nlp.proto
@@ -12,12 +12,6 @@
 
  /*-- MESSAGES ----------------------------------------------------------------*/
 
- message BidiStreamingTokenizationTaskRequest {
-
-   /*-- fields --*/
-   string text_stream = 1;
- }
-
  message ServerStreamingTextGenerationTaskRequest {
 
    /*-- fields --*/

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -7,6 +7,9 @@ use url::Url;
 
 use crate::config::{ServiceConfig, Tls};
 
+pub mod chunker;
+pub use chunker::ChunkerClient;
+
 pub mod detector;
 pub use detector::DetectorClient;
 
@@ -18,6 +21,7 @@ pub use nlp::NlpClient;
 
 pub const DEFAULT_TGIS_PORT: u16 = 8033;
 pub const DEFAULT_CAIKIT_NLP_PORT: u16 = 8085;
+pub const DEFAULT_CHUNKER_PORT: u16 = 8085;
 pub const DEFAULT_DETECTOR_PORT: u16 = 8080;
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
Use a separate chunkers client for the chunker API (assumes a Chunker Service as opposed to an NLP service)

Closes: https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/30