### PR TITLE
Implement error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ rustls-webpki = "0.102.2"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 serde_yml = "0.0.5"
-thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread", "parking_lot", "signal", "sync", "fs"] }
 tokio-stream = "0.1.14"
 tonic = { version = "0.11.0", features = ["tls"] }
@@ -34,6 +33,7 @@ tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 url = "2.5.0"
 validator = { version = "0.18.1", features = ["derive"] } # For API validation
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
+anyhow = "1.0.83"
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ url = "2.5.0"
 validator = { version = "0.18.1", features = ["derive"] } # For API validation
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
 anyhow = "1.0.83"
+thiserror = "1.0.60"
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "fms-guardrails-orchestr8"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.83"
 axum = { version = "0.7.5", features = ["json"] }
 clap = { version = "4.5.3", features = ["derive", "env"] }
 futures = "0.3.30"
@@ -25,16 +26,15 @@ rustls-webpki = "0.102.2"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 serde_yml = "0.0.5"
+thiserror = "1.0.60"
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread", "parking_lot", "signal", "sync", "fs"] }
 tokio-stream = "0.1.14"
 tonic = { version = "0.11.0", features = ["tls"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }
 url = "2.5.0"
-validator = { version = "0.18.1", features = ["derive"] } # For API validation
 uuid = { version = "1.8.0", features = ["v4", "fast-rng"] }
-anyhow = "1.0.83"
-thiserror = "1.0.60"
+validator = { version = "0.18.1", features = ["derive"] } # For API validation
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -34,8 +34,8 @@ pub enum Error {
     Grpc(#[from] tonic::Status),
     #[error("{0}")]
     Http(#[from] reqwest::Error),
-    #[error("invalid model id: {model_id}")]
-    InvalidModelId { model_id: String },
+    #[error("model not found: {model_id}")]
+    ModelNotFound { model_id: String },
 }
 
 impl Error {
@@ -61,17 +61,9 @@ impl Error {
                 Some(code) => code,
                 None => StatusCode::INTERNAL_SERVER_ERROR,
             },
-            // Return 422 for invalid model id
-            Error::InvalidModelId { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+            // Return 404 for model not found
+            Error::ModelNotFound { .. } => StatusCode::NOT_FOUND,
         }
-    }
-
-    /// Returns true for validation-type errors (400/422) and false for other types.
-    pub fn is_validation_error(&self) -> bool {
-        matches!(
-            self.status_code(),
-            StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
-        )
     }
 }
 

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -116,7 +116,7 @@ pub async fn create_http_clients(
                     panic!("error reading cert from {cert_path:?}: {error}")
                 });
                 let identity = reqwest::Identity::from_pem(&cert_pem)
-                    .unwrap_or_else(|error| panic!("error creating identity: {error}"));
+                    .unwrap_or_else(|error| panic!("error parsing cert: {error}"));
                 builder = builder.use_rustls_tls().identity(identity);
             }
             let client = builder

--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -1,12 +1,13 @@
 use std::{collections::HashMap, pin::Pin};
 
+use anyhow::{Context, Error};
 use futures::{Stream, StreamExt};
 use ginepro::LoadBalancedChannel;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request;
 
-use super::{create_grpc_clients, Error};
+use super::create_grpc_clients;
 use crate::{
     config::ServiceConfig,
     pb::{
@@ -35,7 +36,7 @@ impl ChunkerClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::ModelNotFound(model_id.into()))?
+            .context(format!("model not found, model_id={model_id}"))?
             .clone())
     }
 

--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -35,7 +35,7 @@ impl ChunkerClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::InvalidModelId {
+            .ok_or_else(|| Error::ModelNotFound {
                 model_id: model_id.to_string(),
             })?
             .clone())

--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -1,13 +1,12 @@
 use std::{collections::HashMap, pin::Pin};
 
-use anyhow::{Context, Error};
 use futures::{Stream, StreamExt};
 use ginepro::LoadBalancedChannel;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request;
 
-use super::create_grpc_clients;
+use super::{create_grpc_clients, Error};
 use crate::{
     config::ServiceConfig,
     pb::{
@@ -27,16 +26,18 @@ pub struct ChunkerClient {
 }
 
 impl ChunkerClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Result<Self, Error> {
-        let clients = create_grpc_clients(default_port, config, ChunkersServiceClient::new).await?;
-        Ok(Self { clients })
+    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
+        let clients = create_grpc_clients(default_port, config, ChunkersServiceClient::new).await;
+        Self { clients }
     }
 
     fn client(&self, model_id: &str) -> Result<ChunkersServiceClient<LoadBalancedChannel>, Error> {
         Ok(self
             .clients
             .get(model_id)
-            .context(format!("model not found, model_id={model_id}"))?
+            .ok_or_else(|| Error::InvalidModelId {
+                model_id: model_id.to_string(),
+            })?
             .clone())
     }
 

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -22,7 +22,7 @@ impl DetectorClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::InvalidModelId {
+            .ok_or_else(|| Error::ModelNotFound {
                 model_id: model_id.to_string(),
             })?
             .clone())

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
+use anyhow::{Context, Error};
 use serde::{Deserialize, Serialize};
 
-use super::{create_http_clients, Error, HttpClient};
+use super::{create_http_clients, HttpClient};
 use crate::config::ServiceConfig;
 
 const DETECTOR_ID_HEADER_NAME: &str = "detector-id";
@@ -23,7 +24,7 @@ impl DetectorClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::ModelNotFound(model_id.into()))?
+            .context(format!("model not found, model_id={model_id}"))?
             .clone())
     }
 

--- a/src/clients/nlp.rs
+++ b/src/clients/nlp.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
+use anyhow::{Context, Error};
 use futures::StreamExt;
 use ginepro::LoadBalancedChannel;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request;
 
-use super::{create_grpc_clients, Error};
+use super::create_grpc_clients;
 use crate::{
     config::ServiceConfig,
     pb::{
@@ -38,7 +39,7 @@ impl NlpClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::ModelNotFound(model_id.into()))?
+            .context(format!("model not found, model_id={model_id}"))?
             .clone())
     }
 

--- a/src/clients/nlp.rs
+++ b/src/clients/nlp.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
-use anyhow::{Context, Error};
 use futures::StreamExt;
 use ginepro::LoadBalancedChannel;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request;
 
-use super::create_grpc_clients;
+use super::{create_grpc_clients, Error};
 use crate::{
     config::ServiceConfig,
     pb::{
@@ -30,16 +29,18 @@ pub struct NlpClient {
 }
 
 impl NlpClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Result<Self, Error> {
-        let clients = create_grpc_clients(default_port, config, NlpServiceClient::new).await?;
-        Ok(Self { clients })
+    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
+        let clients = create_grpc_clients(default_port, config, NlpServiceClient::new).await;
+        Self { clients }
     }
 
     fn client(&self, model_id: &str) -> Result<NlpServiceClient<LoadBalancedChannel>, Error> {
         Ok(self
             .clients
             .get(model_id)
-            .context(format!("model not found, model_id={model_id}"))?
+            .ok_or_else(|| Error::InvalidModelId {
+                model_id: model_id.to_string(),
+            })?
             .clone())
     }
 

--- a/src/clients/nlp.rs
+++ b/src/clients/nlp.rs
@@ -38,7 +38,7 @@ impl NlpClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::InvalidModelId {
+            .ok_or_else(|| Error::ModelNotFound {
                 model_id: model_id.to_string(),
             })?
             .clone())

--- a/src/clients/tgis.rs
+++ b/src/clients/tgis.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
+use anyhow::{Context, Error};
 use futures::StreamExt;
 use ginepro::LoadBalancedChannel;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
-use super::{create_grpc_clients, Error};
+use super::create_grpc_clients;
 use crate::{
     config::ServiceConfig,
     pb::fmaas::{
@@ -36,7 +37,7 @@ impl TgisClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::ModelNotFound(model_id.into()))?
+            .context(format!("model not found, model_id={model_id}"))?
             .clone())
     }
 

--- a/src/clients/tgis.rs
+++ b/src/clients/tgis.rs
@@ -35,7 +35,7 @@ impl TgisClient {
         Ok(self
             .clients
             .get(model_id)
-            .ok_or_else(|| Error::InvalidModelId {
+            .ok_or_else(|| Error::ModelNotFound {
                 model_id: model_id.to_string(),
             })?
             .clone())

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,8 +108,10 @@ impl OrchestratorConfig {
         todo!()
     }
 
-    pub fn get_chunker_id(&self, detector_id: &str) -> String {
-        self.detectors.get(detector_id).unwrap().chunker_id.clone()
+    pub fn get_chunker_id(&self, detector_id: &str) -> Option<String> {
+        self.detectors
+            .get(detector_id)
+            .map(|detector_config| detector_config.chunker_id.clone())
     }
 }
 
@@ -126,8 +128,9 @@ fn service_tls_name_to_config(
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Error;
+
     use super::*;
-    use crate::Error;
 
     #[test]
     fn test_deserialize_config() -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,43 +1,8 @@
 #![allow(clippy::iter_kv_map, clippy::enum_variant_names)]
 
-use axum::{http::StatusCode, Json};
-
 mod clients;
 mod config;
 mod models;
 mod orchestrator;
 mod pb;
 pub mod server;
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error(transparent)]
-    ClientError(#[from] crate::clients::Error),
-    #[error(transparent)]
-    IoError(#[from] std::io::Error),
-    #[error(transparent)]
-    YamlError(#[from] serde_yml::Error),
-}
-
-// TODO: create better errors and properly convert
-impl From<Error> for (StatusCode, Json<String>) {
-    fn from(value: Error) -> Self {
-        use Error::*;
-        match value {
-            ClientError(error) => match error {
-                clients::Error::ModelNotFound(message) => {
-                    (StatusCode::UNPROCESSABLE_ENTITY, Json(message))
-                }
-                clients::Error::ReqwestError(error) => {
-                    (StatusCode::INTERNAL_SERVER_ERROR, Json(error.to_string()))
-                }
-                clients::Error::TonicError(error) => {
-                    (StatusCode::INTERNAL_SERVER_ERROR, Json(error.to_string()))
-                }
-                clients::Error::IoError(_) => todo!(),
-            },
-            IoError(_) => todo!(),
-            YamlError(_) => todo!(),
-        }
-    }
-}

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -142,13 +142,15 @@ impl Orchestrator {
             }
         });
         match task_handle.await {
+            // Task completed successfully
             Ok(Ok(result)) => Ok(result),
+            // Task failed, return error propagated from child task that failed
             Ok(Err(error)) => {
                 error!(request_id = ?task.request_id, %error, "unary task failed");
                 Err(error)
             }
+            // Task cancelled or panicked
             Err(error) => {
-                // Task failed due to cancellation or panic
                 let error = error.into();
                 error!(request_id = ?task.request_id, %error, "unary task failed");
                 Err(error)

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -189,7 +189,7 @@ async fn chunk_and_detect(
             let chunker_id =
                 ctx.config
                     .get_chunker_id(detector_id)
-                    .ok_or_else(|| Error::InvalidDetectorId {
+                    .ok_or_else(|| Error::DetectorNotFound {
                         detector_id: detector_id.clone(),
                     })?;
             Ok::<String, Error>(chunker_id)
@@ -235,11 +235,12 @@ async fn detect(
             let ctx = ctx.clone();
             let detector_id = detector_id.clone();
             let detector_params = detector_params.clone();
-            let chunker_id = ctx.config.get_chunker_id(&detector_id).ok_or_else(|| {
-                Error::InvalidDetectorId {
-                    detector_id: detector_id.clone(),
-                }
-            })?;
+            let chunker_id =
+                ctx.config
+                    .get_chunker_id(&detector_id)
+                    .ok_or_else(|| Error::DetectorNotFound {
+                        detector_id: detector_id.clone(),
+                    })?;
             let chunks = chunks.get(&chunker_id).unwrap().clone();
             Ok(tokio::spawn(async move {
                 handle_detection_task(ctx, detector_id, detector_params, chunks).await

--- a/src/orchestrator/errors.rs
+++ b/src/orchestrator/errors.rs
@@ -1,0 +1,64 @@
+use reqwest::StatusCode;
+
+use crate::clients;
+
+/// Orchestrator errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid detector: detector_id={detector_id}")]
+    InvalidDetectorId { detector_id: String },
+    #[error("invalid chunker: chunker_id={chunker_id}")]
+    InvalidChunkerId { chunker_id: String },
+    #[error("detector request failed for detector_id={detector_id}: {error}")]
+    DetectorRequestFailed {
+        detector_id: String,
+        error: clients::Error,
+    },
+    #[error("chunker request failed for chunker_id={chunker_id}: {error}")]
+    ChunkerRequestFailed {
+        chunker_id: String,
+        error: clients::Error,
+    },
+    #[error("generate request failed for model_id={model_id}: {error}")]
+    GenerateRequestFailed {
+        model_id: String,
+        error: clients::Error,
+    },
+    #[error("tokenize request failed for model_id={model_id}: {error}")]
+    TokenizeRequestFailed {
+        model_id: String,
+        error: clients::Error,
+    },
+    #[error("task cancelled")]
+    Cancelled,
+    #[error("{0}")]
+    Other(String),
+}
+
+impl Error {
+    /// Returns true for validation-type errors and false for other types.
+    pub fn is_validation_error(&self) -> bool {
+        use Error::*;
+        match self {
+            InvalidDetectorId { .. } | InvalidChunkerId { .. } => true,
+            DetectorRequestFailed { error, .. }
+            | ChunkerRequestFailed { error, .. }
+            | GenerateRequestFailed { error, .. }
+            | TokenizeRequestFailed { error, .. } => matches!(
+                error.status_code(),
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
+            ),
+            _ => false,
+        }
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    fn from(error: tokio::task::JoinError) -> Self {
+        if error.is_cancelled() {
+            Self::Cancelled
+        } else {
+            Self::Other(format!("task panicked: {error}"))
+        }
+    }
+}

--- a/src/orchestrator/errors.rs
+++ b/src/orchestrator/errors.rs
@@ -1,14 +1,10 @@
-use reqwest::StatusCode;
-
 use crate::clients;
 
 /// Orchestrator errors.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("invalid detector: detector_id={detector_id}")]
-    InvalidDetectorId { detector_id: String },
-    #[error("invalid chunker: chunker_id={chunker_id}")]
-    InvalidChunkerId { chunker_id: String },
+    #[error("detector not found: {detector_id}")]
+    DetectorNotFound { detector_id: String },
     #[error("detector request failed for detector_id={detector_id}: {error}")]
     DetectorRequestFailed {
         detector_id: String,
@@ -33,24 +29,6 @@ pub enum Error {
     Cancelled,
     #[error("{0}")]
     Other(String),
-}
-
-impl Error {
-    /// Returns true for validation-type errors and false for other types.
-    pub fn is_validation_error(&self) -> bool {
-        use Error::*;
-        match self {
-            InvalidDetectorId { .. } | InvalidChunkerId { .. } => true,
-            DetectorRequestFailed { error, .. }
-            | ChunkerRequestFailed { error, .. }
-            | GenerateRequestFailed { error, .. }
-            | TokenizeRequestFailed { error, .. } => matches!(
-                error.status_code(),
-                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY
-            ),
-            _ => false,
-        }
-    }
 }
 
 impl From<tokio::task::JoinError> for Error {


### PR DESCRIPTION
This PR implements initial error handling using 3 layers of errors:

1. `clients::Error` is a low-level error that wraps grpc and http client errors.
    - Implements `status_code()` method to return the actual (http client) or mapped (grpc client) http status code. This is useful for pattern-matching specific types of errors.
2. `orchestrator::Error` contains variants for issues that may arise during processing of tasks, such as `DetectorNotFound`, `DetectorRequestFailed`, etc. We can extend this as-needed.
3. `server::Error` is a high-level error returned to the caller, enabling them to react accordingly to validation and not found errors from the orchestrator and downstream services.
   - Implements `axum::IntoResponse` to return 422 for validation-type errors (with a detailed message), 404 for not found errors, and 500 (with generic “unexpected error” message) for other errors.
        ```rust
        /// High-level errors to return to clients.
        #[derive(Debug, thiserror::Error)]
        pub enum Error {
            #[error("{0}")]
            Validation(String),
            #[error("{0}")]
            NotFound(String),
            #[error("unexpected error occured while processing request")]
            Unexpected,
        }
        
        impl From<orchestrator::Error> for Error {
            fn from(error: orchestrator::Error) -> Self {
                use orchestrator::Error::*;
                match error {
                    DetectorNotFound { .. } => Self::NotFound(error.to_string()),
                    DetectorRequestFailed { error, .. }
                    | ChunkerRequestFailed { error, .. }
                    | GenerateRequestFailed { error, .. }
                    | TokenizeRequestFailed { error, .. } => match error.status_code() {
                        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => {
                            Self::Validation(error.to_string())
                        }
                        StatusCode::NOT_FOUND => Self::NotFound(error.to_string()),
                        _ => Self::Unexpected,
                    },
                    _ => Self::Unexpected,
                }
            }
        }
        ```

- Propagates errors from orchestrator tasks
- Logs `orchestrator::Error` to provide sufficient detail for debugging
- Adds response debug logging statements for chunker/detector/generation client calls
- Updates `create_http_clients` and `create_grpc_clients` to panic rather than return `Result` and updates `Client::new` methods and `orchestrator::create_clients` accordingly

Examples:

1. Invalid `detector_id` provided in request
   Server response:
    ```json
    {
	    "code": 404,
	    "details": "detector not found: not_a_model"
    }
    ```
    Error log:
    ```
    ERROR fms_guardrails_orchestr8::orchestrator: unary task failed request_id=deaba6cc-9d69-43e0-81dc-3c4ab73532a2 error=detector not found: not_a_model
    ```
2. Cannot connect to chunker service
    Server response: 
    ```json
    {
	    "code": 500,
	    "details": "unexpected error occured while processing request"
    }
    ```
    Error log:
    ```
    ERROR fms_guardrails_orchestr8::orchestrator: unary task failed request_id=09108c5b-00ab-47d2-8195-5032e0a43a62 error=chunker request failed for chunker_id=en_chunker: error trying to connect: tcp connect error: Connection refused (os error 61)
    ```


