### PR TITLE
:bug: Fix title of objects in detector API spec

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -518,7 +518,7 @@ components:
       type: object
       required:
         - contents
-      title: TextAnalysisHttpRequest
+      title: ContentAnalysisHttpRequest
     ContentsAnalysisResponse:
       type: array
       items:
@@ -556,4 +556,4 @@ components:
         - detection
         - detection_type
         - score
-      title: TextAnalysisResponse
+      title: ContentAnalysisResponse


### PR DESCRIPTION
## Changes
- Fix title names for the content analysis request response