### PR TITLE
:technologist: Rename prompt to content for context analysis API

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -258,9 +258,9 @@ components:
       title: ChatAnalysisResponse
     ContextAnalysisHttpRequest:
       properties:
-        prompt:
+        content:
           type: string
-          title: Prompt
+          title: Content
           example: What is the name of the solar powered car race held every two years?
         context_type:
           allOf:


### PR DESCRIPTION
closes: https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/54

### Changes
- Rename `prompt` to Content` for context analysis detector API