### PR TITLE
:technologist: Update error object in API to fix data type for code

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -448,7 +448,7 @@ components:
       type: object
       properties:
         code:
-          type: string
+          type: number
         message:
           type: string
       required:

--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -172,7 +172,7 @@ components:
       type: object
       properties:
         code:
-          type: string
+          type: number
         details:
           type: string
       required:


### PR DESCRIPTION
### Changes
- Update error object in detectors API to fix data type of `code` 