### PR TITLE
Documenting dependencies to install project on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Orchestrator server for invocation of detectors on text generation input and out
 Make sure Rust and Cargo are [installed](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 Make sure you install protobuf.
 
-### Instructions for Fedora:
+### Instructions for Fedora
 ```sh
 # Install system dependencies
 sudo dnf install git rustup gcc perl

--- a/README.md
+++ b/README.md
@@ -9,16 +9,22 @@ Orchestrator server for invocation of detectors on text generation input and out
 Make sure Rust and Cargo are [installed](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 Also, make sure you install perl and protobuf.
 
-You can run the following command to install dependencies on Fedora:
+You can run the following commands to install dependencies on Fedora:
 ```sh
-sudo dnf install git rustup gcc perl protobuf-devel
+# Install system dependencies
+sudo dnf install git rustup gcc perl
+
+# Install protoc
+PROTOC_VERSION=26.0
+cd /tmp
+curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+unzip protoc-*.zip -d /usr/local && rm protoc-*.zip
+
+# Install Rust tools
+rustup-init -y
+. ~/.bashrc # If you're on bash, so commands rustc and cargo become available.
 ```
 
-After installing dependencies, you should be able to install rust tools by running the commands below.
-```sh
-rustup-init # choose option 1 (default installation)
-. ~/.bashrc # If you're on bash
-```
 
 To build and install the binary locally:
 ```sh

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Orchestrator server for invocation of detectors on text generation input and out
 ## Getting Started
 
 Make sure Rust and Cargo are [installed](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-Also, make sure you install perl and protobuf.
+Make sure you install protobuf.
 
-You can run the following commands to install dependencies on Fedora:
+### Instructions for Fedora:
 ```sh
 # Install system dependencies
 sudo dnf install git rustup gcc perl
@@ -23,8 +23,6 @@ unzip protoc-*.zip -d /usr/local && rm protoc-*.zip
 # Install Rust tools
 rustup-init -y
 . ~/.bashrc # If you're on bash, so commands rustc and cargo become available.
-```
-
 
 To build and install the binary locally:
 ```sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ Orchestrator server for invocation of detectors on text generation input and out
 ## Getting Started
 
 Make sure Rust and Cargo are [installed](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+Also, make sure you install perl and protobuf.
+
+You can run the following command to install dependencies on Fedora:
+```sh
+sudo dnf install git rustup gcc perl protobuf-devel
+```
+
+After installing dependencies, you should be able to install rust tools by running the commands below.
+```sh
+rustup-init # choose option 1 (default installation)
+. ~/.bashrc # If you're on bash
+```
 
 To build and install the binary locally:
 ```sh


### PR DESCRIPTION
I'm running a Fedora 40 machine and I had multiple errors when trying to run `cargo install --path .`
I realized these error messages were related to missing dependencies so, once I managed to successfully run the command on my machine, I spinned up a [Fedora 40 container](https://hub.docker.com/_/fedora) to figure out what where the packages needed to successfully compile the project.
This PR updates the README with the required dependencies to successfully build the project.