### PR TITLE
Fix warnings field not returning if empty (null expected)

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -281,7 +281,6 @@ pub struct ClassifiedGeneratedTextResult {
 
     /// Vector of warnings on input detection
     #[serde(rename = "warnings")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<InputWarning>>,
 
     /// Individual generated tokens and associated details, if requested


### PR DESCRIPTION
This PR addresses issue [#73 ](https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/73), specifically missing`warnings`. See this https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/73#issuecomment-2166613532 for `seed` part.