### PR TITLE
Add pre-commit hooks for Rust

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+      - id: cargo-check
+      - id: clippy

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ To build documenation:
 cargo doc
 ```
 
+If you wish to contribute to the project, make sure you install pre-commit hooks to have automated checks for Rust before every commit (requires [pre-commit](https://pre-commit.com) to be installed in the system).
+
+```
+# You can skip this step if you already have it installed.
+pip install pre-commit
+```
+
+Once you have pre-commit installed, run the following command on the project folder to install the pre-commit hooks:
+```
+pre-commit install
+```
+
 ### Sample requests
 
 1. Guardrails with text generation


### PR DESCRIPTION
This PR addresses #12, and also adds basic documentation on how to use pre-commit hooks.