### PR TITLE
:bug: Fix model id configuration bug for nlp client and rename tgis-router to common-router

### DIFF
--- a/src/clients/nlp.rs
+++ b/src/clients/nlp.rs
@@ -34,7 +34,9 @@ impl NlpClient {
         Self { clients }
     }
 
-    fn client(&self, model_id: &str) -> Result<NlpServiceClient<LoadBalancedChannel>, Error> {
+    fn client(&self, _model_id: &str) -> Result<NlpServiceClient<LoadBalancedChannel>, Error> {
+        // NOTE: We currently forward requests to common router, so we use a single client.
+        let model_id = "common-router";
         Ok(self
             .clients
             .get(model_id)

--- a/src/clients/tgis.rs
+++ b/src/clients/tgis.rs
@@ -32,8 +32,8 @@ impl TgisClient {
         &self,
         _model_id: &str,
     ) -> Result<GenerationServiceClient<LoadBalancedChannel>, Error> {
-        // NOTE: We currently forward requests to the tgis-router, so we use a single client.
-        let model_id = "tgis-router";
+        // NOTE: We currently forward requests to the common-router, so we use a single client.
+        let model_id = "common-router";
         Ok(self
             .clients
             .get(model_id)

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -601,7 +601,7 @@ async fn create_clients(
         GenerationProvider::Tgis => {
             let client = TgisClient::new(
                 clients::DEFAULT_TGIS_PORT,
-                &[("tgis-router".to_string(), config.generation.service.clone())],
+                &[("common-router".to_string(), config.generation.service.clone())],
             )
             .await;
             GenerationClient::Tgis(client)
@@ -609,7 +609,7 @@ async fn create_clients(
         GenerationProvider::Nlp => {
             let client = NlpClient::new(
                 clients::DEFAULT_CAIKIT_NLP_PORT,
-                &[("tgis-router".to_string(), config.generation.service.clone())],
+                &[("common-router".to_string(), config.generation.service.clone())],
             )
             .await;
             GenerationClient::Nlp(client)


### PR DESCRIPTION
closes: #88 

### Changes
- Fix nlp client `model_id` lookup 
- Rename `tgis_router` to `common-router` 