### PR TITLE
:goal_net: Handle unexpected detector responses

### DIFF
--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -387,6 +387,11 @@ async fn handle_detection_task(
         ?response,
         "received detector response"
     );
+    if chunks.len() != response.len() {
+        return Err(Error::Other(format!(
+            "Detector {detector_id} did not return expected number of responses"
+        )));
+    }
     let results = chunks
         .into_iter()
         .zip(response)


### PR DESCRIPTION
Related to #96 - if a detector is not returning the expected number of responses [one per chunk] we want to surface an error rather than provide incorrect results

Error log example - `2024-06-25T20:17:15.224226Z ERROR fms_guardrails_orchestr8::orchestrator: unary task failed request_id=5718f002-1621-4667-9e6f-53b28e048e5b error=Detector xyz did not return expected number of responses`

User sees `{"code":500,"details":"unexpected error occured while processing request"}` [since this is not a user-fixable error]

Closes: #100 