### PR TITLE
Add ssl package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} as fms-guardrails-orchestr8
 COPY --from=fms-guardrails-orchestr8-builder /app/bin/ /app/bin/
 COPY config /app/config
 
-RUN microdnf install -y --disableplugin=subscription-manager shadow-utils && \
+RUN microdnf install -y --disableplugin=subscription-manager shadow-utils compat-openssl11 && \
     microdnf clean all --disableplugin=subscription-manager
 
 RUN groupadd --system orchestr8 --gid 1001 && \


### PR DESCRIPTION
Adding `compat-openssl11` to the image seems to fix #113 (thanks, @declark1!).

![image](https://github.com/foundation-model-stack/fms-guardrails-orchestrator/assets/19861348/8eae2bac-8a7e-48a5-9074-b7583907658b)
