### PR TITLE
Implement `/api/v1/text/task/detection/content` endpoint

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -348,10 +348,6 @@ impl TextContentDetectionHttpRequest {
 /// The response format of the /api/v1/text/task/detection/content endpoint
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TextContentDetectionResult {
-    /// The content to run detectors on
-    #[serde(rename = "content")]
-    pub content: String,
-
     /// Detection results
     #[serde(rename = "detections")]
     pub detections: Vec<TokenClassificationResult>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -319,6 +319,43 @@ pub struct ClassifiedGeneratedTextResult {
     pub input_tokens: Option<Vec<GeneratedToken>>,
 }
 
+/// The request format expected in the /api/v1/text/task/detection/content endpoint.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TextContentDetectionHttpRequest {
+    /// The content to run detectors on
+    #[serde(rename = "content")]
+    pub content: String,
+
+    /// The map of detectors to be used, along with their respective parameters, e.g. thresholds.
+    #[serde(rename = "detectors")]
+    pub detectors: HashMap<String, DetectorParams>,
+}
+
+impl TextContentDetectionHttpRequest {
+    /// Upfront validation of user request
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        // Validate required parameters
+        if self.content.is_empty() {
+            return Err(ValidationError::Required("content".into()));
+        }
+        if self.detectors.is_empty() {
+            return Err(ValidationError::Required("detectors".into()));
+        }
+        Ok(())
+    }
+}
+
+/// The response format of the /api/v1/text/task/detection/content endpoint
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TextContentDetectionResult {
+    /// The content to run detectors on
+    #[serde(rename = "content")]
+    pub content: String,
+
+    /// Detection results
+    #[serde(rename = "detections")]
+    pub detections: Vec<TokenClassificationResult>,
+}
 /// Streaming classification result on text produced by a text generation model, containing
 /// information from the original text generation output as well as the result of
 /// classification on the generated text. Also indicates where in stream is processed.

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -32,7 +32,8 @@ use crate::{
     },
     config::{GenerationProvider, OrchestratorConfig},
     models::{
-        DetectorParams, GuardrailsConfig, GuardrailsHttpRequest, GuardrailsTextGenerationParameters,
+        DetectorParams, GuardrailsConfig, GuardrailsHttpRequest,
+        GuardrailsTextGenerationParameters, TextContentDetectionHttpRequest,
     },
 };
 
@@ -172,6 +173,29 @@ impl ClassificationWithGenTask {
             inputs: request.inputs,
             guardrails_config: request.guardrail_config.unwrap_or_default(),
             text_gen_parameters: request.text_gen_parameters,
+        }
+    }
+}
+
+/// Task for the /api/v1/text/task/detection/content endpoint
+#[derive(Debug)]
+pub struct TextContentDetectionTask {
+    /// Request unique identifier
+    pub request_id: Uuid,
+
+    /// Content to run detection on
+    pub content: String,
+
+    /// Detectors configuration
+    pub detectors: HashMap<String, DetectorParams>,
+}
+
+impl TextContentDetectionTask {
+    pub fn new(request_id: Uuid, request: TextContentDetectionHttpRequest) -> Self {
+        Self {
+            request_id,
+            content: request.content,
+            detectors: request.detectors,
         }
     }
 }

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -149,7 +149,7 @@ impl Orchestrator {
             let detections = input_detection_task(&ctx, &detectors, content.clone(), None).await?;
             debug!(?detections);
 
-            // Send result with input detections
+            // Send result with detections
             Ok(TextContentDetectionResult {
                 content,
                 detections: detections.unwrap_or(vec![]),

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -151,7 +151,6 @@ impl Orchestrator {
 
             // Send result with detections
             Ok(TextContentDetectionResult {
-                content,
                 detections: detections.unwrap_or(vec![]),
             })
         });


### PR DESCRIPTION
This addresses #124.

No unit tests were added as most of the code is reused from the `/api/v1/task/classification-with-text-generation` endpoint was reused. We will add integration tests for this endpoint once we start working on these.