### PR TITLE
:sparkles: Add include_stop_sequence

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -649,6 +649,9 @@ components:
         token_ranks:
           type: boolean
           title: Token Ranks
+        include_stop_sequence:
+          type: boolean
+          title: Include Stop Sequence
       additionalProperties: false
       type: object
       title: Guardrails Text Generation Parameters

--- a/protos/caikit_runtime_Nlp.proto
+++ b/protos/caikit_runtime_Nlp.proto
@@ -34,6 +34,7 @@
    optional bool generated_tokens = 17;
    optional bool token_logprobs = 18;
    optional bool token_ranks = 19;
+   optional bool include_stop_sequence = 20;
  }
 
  message TextGenerationTaskRequest {
@@ -58,6 +59,7 @@
    optional bool generated_tokens = 17;
    optional bool token_logprobs = 18;
    optional bool token_ranks = 19;
+   optional bool include_stop_sequence = 20;
  }
 
  message TokenizationTaskRequest {

--- a/src/clients/generation.rs
+++ b/src/clients/generation.rs
@@ -137,6 +137,7 @@ impl GenerationClient {
                         generated_tokens: params.generated_tokens,
                         token_logprobs: params.token_logprobs,
                         token_ranks: params.token_ranks,
+                        include_stop_sequence: params.include_stop_sequence,
                     }
                 } else {
                     TextGenerationTaskRequest {
@@ -202,6 +203,7 @@ impl GenerationClient {
                         generated_tokens: params.generated_tokens,
                         token_logprobs: params.token_logprobs,
                         token_ranks: params.token_ranks,
+                        include_stop_sequence: params.include_stop_sequence,
                     }
                 } else {
                     ServerStreamingTextGenerationTaskRequest {

--- a/src/models.rs
+++ b/src/models.rs
@@ -245,6 +245,12 @@ pub struct GuardrailsTextGenerationParameters {
     #[serde(rename = "token_ranks")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_ranks: Option<bool>,
+
+    /// Whether or not to include stop sequence
+    /// If not specified, default behavior depends on server setting
+    #[serde(rename = "include_stop_sequence")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_stop_sequence: Option<bool>,
 }
 
 /// Parameters to exponentially increase the likelihood of the text generation
@@ -615,7 +621,7 @@ impl From<GuardrailsTextGenerationParameters> for pb::fmaas::Parameters {
             min_new_tokens: value.min_new_tokens.unwrap_or_default(),
             time_limit_millis: value.max_time.unwrap_or_default() as u32,
             stop_sequences: value.stop_sequences.unwrap_or_default(),
-            include_stop_sequence: None,
+            include_stop_sequence: value.include_stop_sequence,
         };
         let response = pb::fmaas::ResponseOptions {
             input_text: value.preserve_input_text.unwrap_or_default(),


### PR DESCRIPTION
Surface the `include_stop_sequence` parameter as part of `text_gen_parameters` and pass along to generation clients

Closes: #119 