### PR TITLE
:bug: Fix presence of seed, input_token and token count in streaming resp

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -496,7 +496,7 @@ components:
           type: integer
           title: Start Index
       additionalProperties: false
-      required: ["input_token_count", "token_classification_results", "start_index"]
+      required: ["input_token_count", "token_classification_results"]
       type: object
       title: Classified Generated Text Stream Result
     Error:

--- a/src/models.rs
+++ b/src/models.rs
@@ -375,7 +375,8 @@ pub struct ClassifiedGeneratedTextStreamResult {
 
     /// Result start index for processed text
     #[serde(rename = "start_index")]
-    pub start_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_index: Option<u32>,
 }
 
 /// Results of classification on input to a text generation model (e.g. user prompt)
@@ -735,7 +736,7 @@ impl From<pb::fmaas::GenerationResponse> for ClassifiedGeneratedTextStreamResult
                 output: None,
             },
             processed_index: None,
-            start_index: 0,
+            start_index: Some(0),
         }
     }
 }
@@ -797,7 +798,7 @@ impl From<pb::caikit_data_model::nlp::GeneratedTextStreamResult>
                 output: None,
             },
             processed_index: None,
-            start_index: 0,
+            start_index: None,
         }
     }
 }

--- a/src/orchestrator/aggregators/max_processed_index.rs
+++ b/src/orchestrator/aggregators/max_processed_index.rs
@@ -139,7 +139,7 @@ impl DetectionAggregator for MaxProcessedIndexAggregator {
                     let mut result: ClassifiedGeneratedTextStreamResult =
                         ClassifiedGeneratedTextStreamResult {
                             generated_text: Some(generated_text.clone()),
-                            start_index: chunk.start_index as u32,
+                            start_index: Some(chunk.start_index as u32),
                             processed_index: Some(chunk.processed_index as u32),
                             tokens: Some(tokens),
                             // Populate all fields from last generation response and if not available, then use

--- a/src/orchestrator/aggregators/max_processed_index.rs
+++ b/src/orchestrator/aggregators/max_processed_index.rs
@@ -159,14 +159,13 @@ impl DetectionAggregator for MaxProcessedIndexAggregator {
 
                         let input_token_count = initial_gen_response.input_token_count;
                         let seed = initial_gen_response.seed;
-                        result.input_token_count = input_token_count;
-                        result.seed = seed;
-                    } else if (input_start_index..input_end_index).contains(&1) {
                         // Note: input_tokens is not present in 0th response, so we use `1`
                         let input_tokens = match generations.read().unwrap().get(1) {
                             Some(first_generation) => first_generation.input_tokens.clone(),
                             None => Some([].to_vec()),
                         };
+                        result.input_token_count = input_token_count;
+                        result.seed = seed;
                         result.input_tokens = input_tokens;
                     }
 


### PR DESCRIPTION
### Changes
- Make `start_index` optional, similar to `processed_index` so that the values can be null when this APi is used as generation only, i.e no model is provided
- Make `input_token_count` and `input_tokens` to be present in only 1st / 2nd streamed response, similar to text-generation API behavior, instead of all the streamed responses.
- Make `seed` present in first and last streamed responses