### PR TITLE
:wrench: Allow for configuration of request timeouts per service

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -151,7 +151,7 @@ pub async fn create_http_clients(
             base_url.set_port(Some(port)).unwrap();
             let request_timeout = Duration::from_secs(
                 service_config
-                    .timeout
+                    .request_timeout
                     .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SEC),
             );
             let mut builder = reqwest::ClientBuilder::new()
@@ -218,7 +218,7 @@ async fn create_grpc_clients<C>(
     let clients = config
         .iter()
         .map(|(name, service_config)| async move {
-            let request_timeout = Duration::from_secs(service_config.timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SEC));
+            let request_timeout = Duration::from_secs(service_config.request_timeout.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SEC));
             let mut builder = LoadBalancedChannel::builder((
                 service_config.hostname.clone(),
                 service_config.port.unwrap_or(default_port),

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ pub struct ServiceConfig {
     /// Port for service
     pub port: Option<u16>,
     /// Timeout in seconds for request to be handled
-    pub timeout: Option<u64>,
+    pub request_timeout: Option<u64>,
     /// TLS provider info
     pub tls: Option<Tls>,
 }


### PR DESCRIPTION
`timeout` in each client's service config maximizes flexibility, where each client can provide their own timeout and not be restricted to say, all detectors or all chunkers. Users can then configure each client depending potentially on resources and/or knowledge about the particular client e.g. known slow detector model

Closes: #17 