### PR TITLE
:truck: Rename orchestrator API to v2

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -9,7 +9,7 @@ paths:
         - Text Generation with detectors
       summary: Guardrails Unary Handler
       operationId: >-
-        guardrails_unary_handler_api_v1_task_classification_with_text_generation_post
+        guardrails_unary_handler_api_v1_text_classification_with_text_generation_post
       requestBody:
         content:
           application/json:
@@ -41,7 +41,7 @@ paths:
         - Text Generation with detectors
       summary: Guardrails Server Stream Handler
       operationId: >-
-        guardrails_server_stream_handler_api_v1_task_server_streaming_classification_with_text_generation_post
+        guardrails_server_stream_handler_api_v1_text_server_streaming_classification_with_text_generation_post
       requestBody:
         content:
           application/json:
@@ -73,7 +73,7 @@ paths:
         - Detection tasks
       summary: Detection task on input content
       operationId: >-
-        api_v2_detection_task_content_unary_handler
+        api_v2_detection_text_content_unary_handler
       requestBody:
         content:
           application/json:
@@ -105,7 +105,7 @@ paths:
         - Detection tasks
       summary: Detection task on input chat
       operationId: >-
-        api_v2_detection_task_chat_unary_handler
+        api_v2_detection_text_chat_unary_handler
       requestBody:
         content:
           application/json:
@@ -138,7 +138,7 @@ paths:
         - Detection tasks
       summary: Detection task on input content based on context documents
       operationId: >-
-        api_v2_detection_task_context_docs_unary_handler
+        api_v2_detection_text_context_docs_unary_handler
       requestBody:
         content:
           application/json:
@@ -171,7 +171,7 @@ paths:
         - Text Generation with detectors
       summary: Generation task performing detection on prompt and generated text
       operationId: >-
-        api_v2_detection_task_generation_detection_unary_handler
+        api_v2_detection_text_generation_detection_unary_handler
       requestBody:
         content:
           application/json:

--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -67,13 +67,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /api/v1/text/task/detection/content:
+  /api/v2/text/detection/content:
     post:
       tags:
         - Detection tasks
       summary: Detection task on input content
       operationId: >-
-        api_v1_detection_task_content_unary_handler
+        api_v2_detection_task_content_unary_handler
       requestBody:
         content:
           application/json:
@@ -99,13 +99,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /api/v1/text/task/detection/chat:
+  /api/v2/text/detection/chat:
     post:
       tags:
         - Detection tasks
       summary: Detection task on input chat
       operationId: >-
-        api_v1_detection_task_chat_unary_handler
+        api_v2_detection_task_chat_unary_handler
       requestBody:
         content:
           application/json:
@@ -132,13 +132,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /api/v1/text/task/detection/context-docs:
+  /api/v2/text/detection/context-docs:
     post:
       tags:
         - Detection tasks
       summary: Detection task on input content based on context documents
       operationId: >-
-        api_v1_detection_task_context_docs_unary_handler
+        api_v2_detection_task_context_docs_unary_handler
       requestBody:
         content:
           application/json:
@@ -165,13 +165,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
    
-  /api/v1/text/task/generation-detection:
+  /api/v2/text/generation-detection:
     post:
       tags:
         - Text Generation with detectors
       summary: Generation task performing detection on prompt and generated text
       operationId: >-
-        api_v1_detection_task_generation_detection_unary_handler
+        api_v2_detection_task_generation_detection_unary_handler
       requestBody:
         content:
           application/json:

--- a/docs/architecture/adrs/004-orchestrator-input-only-api-design.md
+++ b/docs/architecture/adrs/004-orchestrator-input-only-api-design.md
@@ -18,21 +18,22 @@ The guardrails orchestrator is designed to provide an end-to-end guardrails expe
 1. The endpoints would be named with the primary "task" they do. For example, for the orchestrator endpoint that does both generation and detection in the same call, the task will be called `generation-detection`. For an endpoint which does `detection` as the primary task with a different "modality", the endpoint will include `detection/chat`, where "chat" is the modality.
 1. Evidences will be added to responses of each endpoint later on, once we have the detectors under any category that actually is able to provide evidences.
 1. All of the endpoints would be prefixed by the modality of the input / output. So for text generation use-cases, the modality would be `text`, for text to image generation, the modality would be `text-image`, for image to image functionalities, the modality would be `image`.
+1. All new endpoints would get released under `v2`, as a change from existing APIs, to indicate API change.
 
 
 ### Endpoints
 
 1. Content
-    - **Endpoint:** `/api/v1/text/task/detection/content`
+    - **Endpoint:** `/api/v2/text/detection/content`
     - **Description:** Endpoint implementing detection task for textual content. This would map to `/text/contents` endpoint of detectors and would target general purpose text content analysis detections. The response from this endpoint would return spans denoting location of the detection.
 1. Chat
-    - **Endpoint:** `/api/v1/text/task/detection/chat`
+    - **Endpoint:** `/api/v2/text/detection/chat`
     - **Description:** This endpoint will implement detection task for chat input and will support detectors, exposed via `/api/v1/text/context/chat` endpoint.
 1. Document Context
-    - **Endpoint:** `/api/v1/text/task/detection/context-docs`
+    - **Endpoint:** `/api/v2/text/detection/context-docs`
     - **Description:** This endpoint will implement detection task for document based context detectors, exposed via `/api/v1/text/context/chat` endpoint.
 1. Generation Detection
-    - **Endpoint:** `/api/v1/text/task/generation-detection`
+    - **Endpoint:** `/api/v2/text/generation-detection`
     - **Description:** This endpoint will use the input prompt and call the LLM generation and run the requested detectors on the `generated_text`. This endpoint will loosely be similar to the "output detection" API we have currently in the end-to-end guardrails experience. However, one big difference is that, this endpoint will support detectors that need both input prompt and detection together to analyze and provide results.
     - **Notes:**
         - Unlike the end-to-end guardrails experience endpoints, i.e. `/api/v1/task/classification-with-text-generation` and `/api/v1/task/server-streaming-classification-with-text-generation`, this endpoint will not accept a `guardrails_config`. This is because detectors supported by this endpoint work on both input and generated text, where the `generated_text` is produced from the full input `prompt`. We can't provide partial input to detectors; otherwise, the outputs may not be accurate.

--- a/src/models.rs
+++ b/src/models.rs
@@ -319,7 +319,7 @@ pub struct ClassifiedGeneratedTextResult {
     pub input_tokens: Option<Vec<GeneratedToken>>,
 }
 
-/// The request format expected in the /api/v1/text/task/detection/content endpoint.
+/// The request format expected in the /api/v2/text/task/detection/content endpoint.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct TextContentDetectionHttpRequest {
     /// The content to run detectors on
@@ -345,7 +345,7 @@ impl TextContentDetectionHttpRequest {
     }
 }
 
-/// The response format of the /api/v1/text/task/detection/content endpoint
+/// The response format of the /api/v2/text/task/detection/content endpoint
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TextContentDetectionResult {
     /// Detection results

--- a/src/models.rs
+++ b/src/models.rs
@@ -319,7 +319,7 @@ pub struct ClassifiedGeneratedTextResult {
     pub input_tokens: Option<Vec<GeneratedToken>>,
 }
 
-/// The request format expected in the /api/v2/text/task/detection/content endpoint.
+/// The request format expected in the /api/v2/text/detection/content endpoint.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct TextContentDetectionHttpRequest {
     /// The content to run detectors on
@@ -345,7 +345,7 @@ impl TextContentDetectionHttpRequest {
     }
 }
 
-/// The response format of the /api/v2/text/task/detection/content endpoint
+/// The response format of the /api/v2/text/detection/content endpoint
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TextContentDetectionResult {
     /// Detection results

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -177,7 +177,7 @@ impl ClassificationWithGenTask {
     }
 }
 
-/// Task for the /api/v1/text/task/detection/content endpoint
+/// Task for the /api/v2/text/task/detection/content endpoint
 #[derive(Debug)]
 pub struct TextContentDetectionTask {
     /// Request unique identifier

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -177,7 +177,7 @@ impl ClassificationWithGenTask {
     }
 }
 
-/// Task for the /api/v2/text/task/detection/content endpoint
+/// Task for the /api/v2/text/detection/content endpoint
 #[derive(Debug)]
 pub struct TextContentDetectionTask {
     /// Request unique identifier

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,7 +52,8 @@ use crate::{
 };
 
 const API_PREFIX: &str = r#"/api/v1/task"#;
-const TEXT_API_PREFIX: &str = r#"/api/v1/text/task"#;
+// New orchestrator API
+const TEXT_API_PREFIX: &str = r#"/api/v2/task"#;
 
 const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PACKAGE_NAME: &str = env!("CARGO_PKG_NAME");

--- a/src/server.rs
+++ b/src/server.rs
@@ -53,7 +53,7 @@ use crate::{
 
 const API_PREFIX: &str = r#"/api/v1/task"#;
 // New orchestrator API
-const TEXT_API_PREFIX: &str = r#"/api/v2/task"#;
+const TEXT_API_PREFIX: &str = r#"/api/v2/text"#;
 
 const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PACKAGE_NAME: &str = env!("CARGO_PKG_NAME");


### PR DESCRIPTION
### Changes

As per team discussion, we want to rename new APIs and put them under `v2` to better align