### PR TITLE
Fix: handle detector client error deserialization error

### DIFF
--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -65,7 +65,14 @@ impl DetectorClient {
         if response.status() == StatusCode::OK {
             Ok(response.json().await?)
         } else {
-            let error = response.json::<DetectorError>().await.unwrap();
+            let code = response.status().as_u16();
+            let error = response
+                .json::<DetectorError>()
+                .await
+                .unwrap_or(DetectorError {
+                    code,
+                    message: "".into(),
+                });
             Err(error.into())
         }
     }


### PR DESCRIPTION
Discovered that an error returned in unexpected form, e.g. a 503 error page with html formatting from the router, can cause a deserialization error resulting in a 500 to the client instead of the actual triggering error code.