### PR TITLE
Implementation of /context endpoint

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -132,7 +132,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /api/v2/text/detection/context-docs:
+  /api/v2/text/detection/context:
     post:
       tags:
         - Detection tasks

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -259,14 +259,23 @@ pub struct ContextDocsDetectionRequest {
     pub content: String,
 
     /// Type of context being sent
-    pub context_type: String,
+    pub context_type: ContextType,
 
     /// Context to run detection on
     pub context: Vec<String>,
 }
 
+/// Enum representing the context type of a detection
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ContextType {
+    #[serde(rename = "docs")]
+    Document,
+    #[serde(rename = "url")]
+    Url,
+}
+
 impl ContextDocsDetectionRequest {
-    pub fn new(content: String, context_type: String, context: Vec<String>) -> Self {
+    pub fn new(content: String, context_type: ContextType, context: Vec<String>) -> Self {
         Self {
             content,
             context_type,

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -81,7 +81,7 @@ impl DetectorClient {
     }
 
     /// Invokes detectors implemented with the `/api/v1/text/generation` endpoint
-    pub async fn generation_detection(
+    pub async fn text_generation(
         &self,
         model_id: &str,
         request: GenerationDetectionRequest,
@@ -110,7 +110,7 @@ impl DetectorClient {
     }
 
     /// Invokes detectors implemented with the `/api/v1/text/context/doc` endpoint
-    pub async fn detect_for_context_documents(
+    pub async fn text_context_doc(
         &self,
         model_id: &str,
         request: ContextDocsDetectionRequest,

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -126,7 +126,14 @@ impl DetectorClient {
         if response.status() == StatusCode::OK {
             Ok(response.json().await?)
         } else {
-            let error = response.json::<DetectorError>().await.unwrap();
+            let code = response.status().as_u16();
+            let error = response
+                .json::<DetectorError>()
+                .await
+                .unwrap_or(DetectorError {
+                    code,
+                    message: "".into(),
+                });
             Err(error.into())
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 
-use crate::pb;
+use crate::{clients::detector::ContextType, pb};
 
 /// Parameters relevant to each detector
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -949,7 +949,7 @@ pub struct ContextDocsHttpRequest {
 
     /// Content to be sent to detector
     #[serde(rename = "context_type")]
-    pub context_type: String,
+    pub context_type: ContextType,
 
     /// Content to be sent to detector
     #[serde(rename = "context")]
@@ -967,12 +967,6 @@ impl ContextDocsHttpRequest {
         if self.content.is_empty() {
             return Err(ValidationError::Required("content".into()));
         }
-
-        if self.context_type.is_empty() {
-            return Err(ValidationError::Required("context_type".into()));
-        } /*else if ["docs", "url"].contains(&self.context_type.as_str()) {
-              return Err(ValidationError::Invalid(format!("context_type must be either 'docs' or 'url'. Got {}", self.context_type).into()));
-          }*/
 
         if self.context.is_empty() {
             return Err(ValidationError::Required("context".into()));

--- a/src/models.rs
+++ b/src/models.rs
@@ -958,7 +958,7 @@ pub struct ContextDocsHttpRequest {
 
 impl ContextDocsHttpRequest {
     /// Upfront validation of user request
-    pub fn _validate(&self) -> Result<(), ValidationError> {
+    pub fn validate(&self) -> Result<(), ValidationError> {
         // Validate required parameters
         if self.detectors.is_empty() {
             return Err(ValidationError::Required("detectors".into()));
@@ -970,9 +970,9 @@ impl ContextDocsHttpRequest {
 
         if self.context_type.is_empty() {
             return Err(ValidationError::Required("context_type".into()));
-        } else if ["docs", "url"].contains(&self.context_type.as_str()) {
-            return Err(ValidationError::Invalid("context_type".into()));
-        }
+        } /*else if ["docs", "url"].contains(&self.context_type.as_str()) {
+              return Err(ValidationError::Invalid(format!("context_type must be either 'docs' or 'url'. Got {}", self.context_type).into()));
+          }*/
 
         if self.context.is_empty() {
             return Err(ValidationError::Required("context".into()));

--- a/src/models.rs
+++ b/src/models.rs
@@ -936,6 +936,58 @@ pub struct DetectionResult {
     pub score: f64,
 }
 
+/// The request format expected in the /api/v1/text/task/generation-detection endpoint.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct ContextDocsHttpRequest {
+    /// The map of detectors to be used, along with their respective parameters, e.g. thresholds.
+    #[serde(rename = "detectors")]
+    pub detectors: HashMap<String, DetectorParams>,
+
+    /// Content to be sent to detector
+    #[serde(rename = "content")]
+    pub content: String,
+
+    /// Content to be sent to detector
+    #[serde(rename = "context_type")]
+    pub context_type: String,
+
+    /// Content to be sent to detector
+    #[serde(rename = "context")]
+    pub context: Vec<String>,
+}
+
+impl ContextDocsHttpRequest {
+    /// Upfront validation of user request
+    pub fn _validate(&self) -> Result<(), ValidationError> {
+        // Validate required parameters
+        if self.detectors.is_empty() {
+            return Err(ValidationError::Required("detectors".into()));
+        }
+
+        if self.content.is_empty() {
+            return Err(ValidationError::Required("content".into()));
+        }
+
+        if self.context_type.is_empty() {
+            return Err(ValidationError::Required("context_type".into()));
+        } else if ["docs", "url"].contains(&self.context_type.as_str()) {
+            return Err(ValidationError::Invalid("context_type".into()));
+        }
+
+        if self.context.is_empty() {
+            return Err(ValidationError::Required("context".into()));
+        }
+        Ok(())
+    }
+}
+
+/// The response format of the /api/v1/text/task/generation-detection endpoint
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ContextDocsResult {
+    #[serde(rename = "detections")]
+    pub detections: Vec<DetectionResult>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/models.rs
+++ b/src/models.rs
@@ -936,7 +936,7 @@ pub struct DetectionResult {
     pub score: f64,
 }
 
-/// The request format expected in the /api/v1/text/task/generation-detection endpoint.
+/// The request format expected in the /api/v2/text/context endpoint.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ContextDocsHttpRequest {
     /// The map of detectors to be used, along with their respective parameters, e.g. thresholds.

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -32,8 +32,9 @@ use crate::{
     },
     config::{GenerationProvider, OrchestratorConfig},
     models::{
-        DetectorParams, GenerationWithDetectionHttpRequest, GuardrailsConfig,
-        GuardrailsHttpRequest, GuardrailsTextGenerationParameters, TextContentDetectionHttpRequest,
+        ContextDocsHttpRequest, DetectorParams, GenerationWithDetectionHttpRequest,
+        GuardrailsConfig, GuardrailsHttpRequest, GuardrailsTextGenerationParameters,
+        TextContentDetectionHttpRequest,
     },
 };
 
@@ -226,6 +227,37 @@ impl TextContentDetectionTask {
         Self {
             request_id,
             content: request.content,
+            detectors: request.detectors,
+        }
+    }
+}
+
+/// Task for the /api/v1/text/task/detection/context-docs endpoint
+#[derive(Debug)]
+pub struct ContextDocsDetectionTask {
+    /// Request unique identifier
+    pub request_id: Uuid,
+
+    /// Content to run detection on
+    pub content: String,
+
+    /// Context type
+    pub context_type: String,
+
+    /// Context
+    pub context: Vec<String>,
+
+    /// Detectors configuration
+    pub detectors: HashMap<String, DetectorParams>,
+}
+
+impl ContextDocsDetectionTask {
+    pub fn new(request_id: Uuid, request: ContextDocsHttpRequest) -> Self {
+        Self {
+            request_id,
+            content: request.content,
+            context_type: request.context_type,
+            context: request.context,
             detectors: request.detectors,
         }
     }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -27,8 +27,8 @@ use uuid::Uuid;
 
 use crate::{
     clients::{
-        self, ChunkerClient, DetectorClient, GenerationClient, NlpClient, TgisClient,
-        COMMON_ROUTER_KEY,
+        self, detector::ContextType, ChunkerClient, DetectorClient, GenerationClient, NlpClient,
+        TgisClient, COMMON_ROUTER_KEY,
     },
     config::{GenerationProvider, OrchestratorConfig},
     models::{
@@ -242,7 +242,7 @@ pub struct ContextDocsDetectionTask {
     pub content: String,
 
     /// Context type
-    pub context_type: String,
+    pub context_type: ContextType,
 
     /// Context
     pub context: Vec<String>,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -232,7 +232,7 @@ impl TextContentDetectionTask {
     }
 }
 
-/// Task for the /api/v1/text/task/detection/context-docs endpoint
+/// Task for the /api/v1/text/task/detection/context endpoint
 #[derive(Debug)]
 pub struct ContextDocsDetectionTask {
     /// Request unique identifier

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -30,7 +30,8 @@ use super::{
 };
 use crate::{
     clients::detector::{
-        ContentAnalysisRequest, ContextDocsDetectionRequest, GenerationDetectionRequest,
+        ContentAnalysisRequest, ContextDocsDetectionRequest, ContextType,
+        GenerationDetectionRequest,
     },
     models::{
         ClassifiedGeneratedTextResult, ContextDocsResult, DetectionResult, DetectorParams,
@@ -503,7 +504,7 @@ pub async fn detect_for_context(
     detector_id: String,
     detector_params: DetectorParams,
     content: String,
-    context_type: String,
+    context_type: ContextType,
     context: Vec<String>,
 ) -> Result<Vec<DetectionResult>, Error> {
     let detector_id = detector_id.clone();

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -912,7 +912,7 @@ mod tests {
             score: 0.9,
         }];
 
-        faux::when!(mock_detector_client.generation_detection(
+        faux::when!(mock_detector_client.text_generation(
             detector_id,
             GenerationDetectionRequest::new(prompt.clone(), generated_text.clone())
         ))
@@ -965,7 +965,7 @@ mod tests {
 
         let expected_response: Vec<DetectionResult> = vec![];
 
-        faux::when!(mock_detector_client.generation_detection(
+        faux::when!(mock_detector_client.text_generation(
             detector_id,
             GenerationDetectionRequest::new(prompt.clone(), generated_text.clone())
         ))

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -482,7 +482,7 @@ pub async fn detect_for_generation(
     debug!(%detector_id, ?request, "sending generation detector request");
     let response = ctx
         .detector_client
-        .generation_detection(&detector_id, request)
+        .text_generation(&detector_id, request)
         .await
         .map(|results| {
             results
@@ -521,7 +521,7 @@ pub async fn detect_for_context(
     debug!(%detector_id, ?request, "sending generation detector request");
     let response = ctx
         .detector_client
-        .detect_for_context_documents(&detector_id, request)
+        .text_context_doc(&detector_id, request)
         .await
         .map(|results| {
             results

--- a/src/server.rs
+++ b/src/server.rs
@@ -160,7 +160,7 @@ pub async fn run(
             post(detection_content),
         )
         .route(
-            &format!("{}/detection/context-docs", TEXT_API_PREFIX),
+            &format!("{}/detection/context", TEXT_API_PREFIX),
             post(detect_context_documents),
         )
         .with_state(shared_state);


### PR DESCRIPTION
This addresses #123. One important point to add is that `context_type` only accepts values "docs" or "url".

Scenarios tested:

* Sample request -> works just fine (base success scenario).
* Missing `context` -> returns 422
* Missing `context_type` -> returns 422
* Missing `detectors` -> returns 422
* Two detectors -> returns detections from both detectors (though the order of detections may vary)
* Threshold filtering -> only detections above the threshold are returned
* Detector returning 404 -> returns 404
* Detector returning 503 -> returns 503
* Detector returning 500 (further details are shown on logs) -> returns 500
* Detector returning 422 -> returns 422
