### PR TITLE
Fixes detections mask not getting last index from text str

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -80,7 +80,8 @@ impl GuardrailsHttpRequest {
             .and_then(|config| config.input.as_ref().and_then(|input| input.masks.as_ref()));
         if let Some(input_masks) = input_masks {
             if !input_masks.iter().all(|(start, end)| {
-                input_range.contains(start) && input_range.contains(end) && start < end
+                let end_ = end - 1;
+                input_range.contains(start) && input_range.contains(&end_) && start < end
             }) {
                 return Err(ValidationError::Invalid("invalid masks".into()));
             }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -327,6 +327,15 @@ mod tests {
         ];
         assert_eq!(text_with_offsets, expected_text_with_offsets)
     }
+    #[test]
+    fn test_apply_masks_including_last_index() {
+        let text = "Hello Gabe! Only the third instance of Gabe will be processed. Hey there Gabe! Nice to meet you.";
+        let masks: Vec<(usize, usize)> = vec![(63, 96)];
+        let text_with_offsets = apply_masks(text.into(), Some(&masks));
+        let expected_text_with_offsets =
+            vec![(63, "Hey there Gabe! Nice to meet you.".to_string())];
+        assert_eq!(text_with_offsets, expected_text_with_offsets)
+    }
 
     #[test]
     fn test_slice_codepoints() {


### PR DESCRIPTION
Running functional tests, came across this issue with this inputs:
```
{
	"inputs": "Hello Gabe! Only the third instance of Gabe will be processed. Hey there Gabe! Nice to meet you.",
	"guardrail_config": {
		"input": {
			"models": {
				"en_syntax_rbr_pii": {}
			},
			"masks": [
				[
					63,
					96
				]
			]
		}
	},
	"model_id": "bloom-560m"
}
```

Url: https://gr2-fmaas-tuning.apps.fmaas-devstage-backend.fmaas.res.ibm.com/api/v1/task/classification-with-text-generation

Error: 
```
{
  "code": 422,
  "details": "invalid masks"
}
```
A simple fix suggested by this PR is to go as far as the last index of the string, without overpassing the text length.