### PR TITLE
Configure explicit tls roots for tonic client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2157,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
  "rustls-pemfile",
  "socket2",
  "tokio",
@@ -2153,6 +2167,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "1.0.63"
 tokio = { version = "1.39.2", features = ["rt", "rt-multi-thread", "parking_lot", "signal", "sync", "fs"] }
 tokio-rustls = { version = "0.26.0" }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
-tonic = { version = "0.12.1", features = ["tls"] }
+tonic = { version = "0.12.1", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 tower-service = "0.3"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter"] }

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -238,7 +238,7 @@ async fn create_grpc_clients<C>(
                     .unwrap_or_else(|error| panic!("error reading key from {key_path:?}: {error}"));
                 let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
                 let mut client_tls_config =
-                    tonic::transport::ClientTlsConfig::new().identity(identity);
+                    tonic::transport::ClientTlsConfig::new().identity(identity).with_native_roots().with_webpki_roots();
                 if let Some(client_ca_cert_path) = &tls_config.client_ca_cert_path {
                     let client_ca_cert_pem = tokio::fs::read(client_ca_cert_path)
                         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,11 @@ struct Args {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args = Args::parse();
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
 
+    let args = Args::parse();
     if args.tls_key_path.is_some() != args.tls_cert_path.is_some() {
         panic!("tls: must provide both cert and key")
     }


### PR DESCRIPTION
Related to (not fully understood) breaking change in tonic 0.12.0 [#1731](https://github.com/hyperium/tonic/pull/1731), which is causing connection timeout in our TLS-enabled tonic clients.