### PR TITLE
:memo: Update evidence for detector API and context docs

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: Detectors API (WIP)
+  title: Detectors API
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -248,12 +248,12 @@ components:
           type: number
           title: Score
           example: 0.684
-        evidences:
+        evidence:
           anyOf:
             - items:
                 $ref: '#/components/schemas/EvidenceObj'
               type: array
-          description: Optional field providing evidences for the provided detection
+          description: Optional field providing evidence for the provided detection
       type: object
       required:
         - detection
@@ -300,12 +300,12 @@ components:
           type: number
           title: Score
           example: 0.5
-        evidences:
+        evidence:
           anyOf:
             - items:
                 $ref: '#/components/schemas/EvidenceObj'
               type: array
-          description: Optional field providing evidences for the provided detection
+          description: Optional field providing evidence for the provided detection
       type: object
       required:
         - detection
@@ -347,68 +347,52 @@ components:
         attributes -- see the documentation for details.
     Evidence:
       properties:
-        source:
+        name:
           type: string
-          title: Source
-          description: source of the evidence, it can be url of the evidence etc
-          example: https://en.wikipedia.org/wiki/IBM
+          title: Name
+          description: Name for the evidence
+          example: context_chunk
+        value:
+          type: string
+          title: Value
+          description: Value for the evidence
+          example: one chunk of context
+        score:
+          type: number
+          title: Score
+          example: 0.5
       type: object
       required:
-        - source
+        - name
+        - value
       title: Evidence
     EvidenceObj:
       properties:
-        type:
-          allOf:
-            - $ref: '#/components/schemas/EvidenceType'
-          description: >-
-            Type field signifying the type of evidence provided. Example url,
-            title etc
-          example: url
+        name:
+          type: string
+          title: Name
+          description: Name for the evidence
+          example: context
+        value:
+          type: string
+          title: Value
+          description: Value for the evidence
+          example: This is one context sentence.
+        score:
+          type: number
+          title: Score
+          example: 0.5
         evidence:
-          allOf:
-            - $ref: '#/components/schemas/Evidence'
-          description: >-
-            Evidence object, currently only containing source, but in future can
-            contain other optional arguments like id, etc
-          example:
-            source: https://en.wikipedia.org/wiki/IBM
+          anyOf:
+            - items:
+                $ref: '#/components/schemas/Evidence'
+              type: array
+          description: Evidence on evidence value
       type: object
       required:
-        - type
+        - name
+        - value
       title: EvidenceObj
-    EvidenceType:
-      type: string
-      enum:
-        - url
-        - title
-      title: EvidenceType
-      description: >-
-        A collection of name/value pairs.
-
-        Access them by:
-
-        - attribute access::
-
-        >>> EvidenceType.url <EvidenceType.url: 'url'>
-
-        - value lookup:
-
-        >>> EvidenceType('url') <EvidenceType.url: 'url'>
-
-        - name lookup:
-
-        >>> EvidenceType['url'] <EvidenceType.url: 'url'>
-
-        Enumerations can be iterated over, and know how many members they have:
-
-        >>> len(EvidenceType) 2
-
-        >>> list(EvidenceType) [<EvidenceType.url: 'url'>, <EvidenceType.title:
-        'title'>]
-
-        Methods can be added to enumerations, and members can have their own
-        attributes -- see the documentation for details.
     GenerationAnalysisHttpRequest:
       properties:
         prompt:
@@ -440,12 +424,12 @@ components:
           type: number
           title: Score
           example: 0.5
-        evidences:
+        evidence:
           anyOf:
             - items:
                 $ref: '#/components/schemas/EvidenceObj'
               type: array
-          description: Optional field providing evidences for the provided detection
+          description: Optional field providing evidence for the provided detection
       type: object
       required:
         - detection
@@ -557,12 +541,12 @@ components:
           type: number
           title: Score
           example: 0.8
-        evidences:
+        evidence:
           anyOf:
             - items:
                 $ref: '#/components/schemas/EvidenceObj'
               type: array
-          description: Optional field providing evidences for the provided detection
+          description: Optional field providing evidence for the provided detection
       type: object
       required:
         - start

--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -385,9 +385,13 @@ components:
               score:
                 type: number
                 title: Score
+              evidence:
+                anyOf:
+                - items:
+                    $ref: '#/components/schemas/EvidenceObj'
+                  type: array
       required: ["detections"]
       title: Detection Context Docs Response
-    
     GenerationDetectionRequest:
       properties:
         model_id:
@@ -592,6 +596,53 @@ components:
       additionalProperties: false
       type: object
       title: Exponential Decay Length Penalty
+    Evidence:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name for the evidence
+          example: context_chunk
+        value:
+          type: string
+          title: Value
+          description: Value for the evidence
+          example: one chunk of context
+        score:
+          type: number
+          title: Score
+          example: 0.5
+      type: object
+      required:
+        - name
+        - value
+      title: Evidence
+    EvidenceObj:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name for the evidence
+          example: context
+        value:
+          type: string
+          title: Value
+          description: Value for the evidence
+          example: This is one context sentence.
+        score:
+          type: number
+          title: Score
+          example: 0.5
+        evidence:
+          anyOf:
+            - items:
+                $ref: '#/components/schemas/Evidence'
+              type: array
+      type: object
+      required:
+        - name
+        - value
+      title: EvidenceObj
     FinishReason:
       type: string
       enum:

--- a/docs/architecture/adrs/003-detector-api-design.md
+++ b/docs/architecture/adrs/003-detector-api-design.md
@@ -44,7 +44,7 @@ Based on the input requirements, the APIs will be divided into following parts:
 1. `/api/v1/text/context/doc` - Context Analysis
     - Providing detection computation of content w.r.t the context provided in the input.
 
-Each of above endpoints will also provide an "evidence" block that will allow future integration with evidences for their response.
+Each of above endpoints will also provide an "evidence" block that will allow future integration with evidence for their response.
 
 ## Consequences
 

--- a/docs/architecture/adrs/004-orchestrator-input-only-api-design.md
+++ b/docs/architecture/adrs/004-orchestrator-input-only-api-design.md
@@ -16,7 +16,7 @@ The guardrails orchestrator is designed to provide an end-to-end guardrails expe
 ### Nomenclature
 
 1. The endpoints would be named with the primary "task" they do. For example, for the orchestrator endpoint that does both generation and detection in the same call, the task will be called `generation-detection`. For an endpoint which does `detection` as the primary task with a different "modality", the endpoint will include `detection/chat`, where "chat" is the modality.
-1. Evidences will be added to responses of each endpoint later on, once we have the detectors under any category that actually is able to provide evidences.
+1. Evidence will be added to responses of each endpoint later on, once we have the detectors under any category that actually is able to provide evidence.
 1. All of the endpoints would be prefixed by the modality of the input / output. So for text generation use-cases, the modality would be `text`, for text to image generation, the modality would be `text-image`, for image to image functionalities, the modality would be `image`.
 1. All new endpoints would get released under `v2`, as a change from existing APIs, to indicate API change.
 

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -195,9 +195,9 @@ pub struct ContentAnalysisResponse {
     pub detection_type: String,
     /// Score of detection
     pub score: f64,
-    /// Optional, any applicable evidences for detection
+    /// Optional, any applicable evidence for detection
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub evidences: Option<Vec<EvidenceObj>>,
+    pub evidence: Option<Vec<EvidenceObj>>,
 }
 
 impl From<ContentAnalysisResponse> for crate::models::TokenClassificationResult {

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -154,30 +154,30 @@ impl ContentAnalysisRequest {
     }
 }
 
-/// Evidence type
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum EvidenceType {
-    Url,
-    Title,
-}
-
-/// Source of the evidence e.g. url
+/// Evidence
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Evidence {
-    /// Evidence source
-    pub source: String,
+    /// Evidence name
+    pub name: String,
+    /// Evidence value
+    pub value: String,
+    /// Optional, score for evidence
+    pub score: Option<f64>,
 }
 
 /// Evidence in response
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EvidenceObj {
-    /// Type field signifying the type of evidence provided
-    #[serde(rename = "type")]
-    pub r#type: EvidenceType,
-    /// Evidence currently only containing source
+    /// Evidence name
+    pub name: String,
+    /// Evidence value
+    pub value: String,
+    /// Optional, score for evidence
+    pub score: Option<f64>,
+    /// Optional, evidence on evidence value
+    // Evidence nesting should likely not go beyond this
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub evidence: Option<Evidence>,
+    pub evidence: Option<Vec<Evidence>>,
 }
 
 /// Response of text content analysis endpoint

--- a/src/orchestrator/aggregators/max_processed_index.rs
+++ b/src/orchestrator/aggregators/max_processed_index.rs
@@ -245,7 +245,7 @@ mod tests {
             detection: detection.to_string(),
             detection_type: detection_type.to_string(),
             score: 0.99,
-            evidences: None,
+            evidence: None,
         }]
         .to_vec()
     }

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -829,7 +829,7 @@ mod tests {
                 detection: "has_HAP".to_string(),
                 detection_type: "hap".to_string(),
                 score: 0.1,
-                evidences: Some(vec![]),
+                evidence: Some(vec![]),
             }],
             vec![ContentAnalysisResponse {
                 start: 0,
@@ -838,7 +838,7 @@ mod tests {
                 detection: "has_HAP".to_string(),
                 detection_type: "hap".to_string(),
                 score: 0.9,
-                evidences: Some(vec![]),
+                evidence: Some(vec![]),
             }],
         ]));
 


### PR DESCRIPTION
This updates the detector API according to the structure as discussed in #159 . For now, `evidence` is expected for the "context docs" orchestrator endpoint i.e. `/text/detection/context`, so only the `DetectionContextDocsResponse` has been updated. As more detectors expose `evidence`, this can be added to the other orchestrator endpoints. One layer of nesting is required for now to expose the information needed by "context docs" endpoint users, but this should be the limit of nesting [more could get even more confusing].

It seems `evidence` is "uncountable" and would account for plurality, so I have updated the API references as so to not refer to "evidences"

Exposing `evidence` through the orchestrator endpoint and actual integration/testing with the "context docs" endpoint will be part of a separate issue/PR #161 