### PR TITLE
:loud_sound: Add http error source logging

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -59,7 +59,7 @@ pub enum Error {
     #[error("{}", .message)]
     Grpc { code: StatusCode, message: String },
     #[error("{}", .message)]
-    Http { code: StatusCode, message: String},
+    Http { code: StatusCode, message: String },
     #[error("model not found: {model_id}")]
     ModelNotFound { model_id: String },
 }
@@ -81,12 +81,14 @@ impl Error {
 
 impl From<reqwest::Error> for Error {
     fn from(value: reqwest::Error) -> Self {
-
-        // Log lower level source of error. 
-        // Examples: 
+        // Log lower level source of error.
+        // Examples:
         // 1. client error (Connect) // Cases like connection error, wrong port etc.
         // 2. client error (SendRequest) // Cases like cert issues
-        error!("http request failed. Source: {}", value.source().unwrap().to_string());
+        error!(
+            "http request failed. Source: {}",
+            value.source().unwrap().to_string()
+        );
         // Return http status code for error responses
         // and 500 for other errors
         let code = match value.status() {

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -16,13 +16,14 @@
 */
 
 #![allow(dead_code)]
-use std::{collections::HashMap, pin::Pin, time::Duration};
+// Import error for adding `source` trait
+use std::{collections::HashMap, error::Error as _, pin::Pin, time::Duration};
 
 use futures::{future::join_all, Stream};
 use ginepro::LoadBalancedChannel;
 use reqwest::StatusCode;
 use tokio::{fs::File, io::AsyncReadExt};
-use tracing::debug;
+use tracing::{debug, error};
 use url::Url;
 
 use crate::config::{ServiceConfig, Tls};
@@ -58,7 +59,7 @@ pub enum Error {
     #[error("{}", .message)]
     Grpc { code: StatusCode, message: String },
     #[error("{}", .message)]
-    Http { code: StatusCode, message: String },
+    Http { code: StatusCode, message: String},
     #[error("model not found: {model_id}")]
     ModelNotFound { model_id: String },
 }
@@ -80,6 +81,12 @@ impl Error {
 
 impl From<reqwest::Error> for Error {
     fn from(value: reqwest::Error) -> Self {
+
+        // Log lower level source of error. 
+        // Examples: 
+        // 1. client error (Connect) // Cases like connection error, wrong port etc.
+        // 2. client error (SendRequest) // Cases like cert issues
+        error!("http request failed. Source: {}", value.source().unwrap().to_string());
         // Return http status code for error responses
         // and 500 for other errors
         let code = match value.status() {


### PR DESCRIPTION
closes: #197 

### Changes
- This PR attempts at adding slightly more information to http errors returned by `reqwest` library. 


### Example

#### Previously 
For cert errors we would only see following in log:
```
error received from detector detector_id=<DETECTOR_ID>error=Http { code: 500, message: "error sending request for url (https://<URL>:8000/api/v1/text/contents)" 

```

For misconfigured port we would see:
```
error received from detector detector_id=<DETECTOR_ID>error=Http { code: 500, message: "error sending request for url (https://<URL>:8000/api/v1/text/contents)" 
```

#### With this PR
For cert error:
```
http request failure. source: client error (SendRequest)
```

For misconfigured port:
```
http request failure. source: client error (Connect)
```


ATM it doesn't seem there is a way to easily get more descriptive error messages from reqwest library, than above.