### PR TITLE
:recycle: Re-order endpoints and add tags

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -3,17 +3,17 @@ info:
   title: FMS Orchestrator API
   version: 0.1.0
 tags:
-    - name: Text Generation with detections
+    - name: Task - Text Generation, with detection
       description: Detections on text generation model input and/or output
-    - name: Detection tasks
+    - name: Task - Detection
       description: Standalone detections
-    - name: Chat Completions with detections
+    - name: Task - Chat Completions, with detection
       description: Detections on list of messages comprising a conversation and/or completions from a model
 paths:
   /api/v1/task/classification-with-text-generation:
     post:
       tags:
-        - Text Generation with detections
+        - Task - Text Generation, with detection
       summary: Guardrails Unary Handler
       operationId: >-
         guardrails_unary_handler_api_v1_text_classification_with_text_generation_post
@@ -45,7 +45,7 @@ paths:
   /api/v1/task/server-streaming-classification-with-text-generation:
     post:
       tags:
-        - Text Generation with detections
+        - Task - Text Generation, with detection
       summary: Guardrails Server Stream Handler
       operationId: >-
         guardrails_server_stream_handler_api_v1_text_server_streaming_classification_with_text_generation_post
@@ -77,7 +77,7 @@ paths:
   /api/v2/text/generation-detection:
     post:
       tags:
-        - Text Generation with detections
+        - Task - Text Generation, with detection
       summary: Generation task performing detection on prompt and generated text
       operationId: >-
         api_v2_detection_text_generation_detection_unary_handler
@@ -110,7 +110,7 @@ paths:
   /api/v2/text/detection/content:
     post:
       tags:
-        - Detection tasks
+        - Task - Detection
       summary: Detection task on input content
       operationId: >-
         api_v2_detection_text_content_unary_handler
@@ -142,7 +142,7 @@ paths:
   /api/v2/text/detection/chat:
     post:
       tags:
-        - Detection tasks
+        - Task - Detection
       summary: Detection task on input chat
       operationId: >-
         api_v2_detection_text_chat_unary_handler
@@ -175,7 +175,7 @@ paths:
   /api/v2/text/detection/context:
     post:
       tags:
-        - Detection tasks
+        - Task - Detection
       summary: Detection task on input content based on context documents
       operationId: >-
         api_v2_detection_text_context_docs_unary_handler
@@ -207,7 +207,7 @@ paths:
   /api/v2/text/detection/generated:
     post:
       tags:
-        - Detection tasks
+        - Task - Detection
       summary: Detection task performing detection on prompt and generated text
       operationId: >-
         api_v2_detection_text_generated_unary_handler


### PR DESCRIPTION
Mainly re-ordering endpoints to group the "text generation" ones together, "detection tasks" one together, and add tags

Goal here is to make endpoints easier to navigate for any devs trying to add more