### PR TITLE
Add detector type to config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,8 +26,9 @@ chunkers:
 detectors:
     # Detector ID/name to be used in user requests
     hap-en:
+        type: content # content, chat, context, generated
         service:
-            hostname: https://localhost/api/v1/text/contents # Full url / endpoint currently expected
+            hostname: localhost
             port: 8080
             # TLS ID/name, optional (detailed in `tls` section)
             tls: detector

--- a/docs/architecture/adrs/005-detector-type.md
+++ b/docs/architecture/adrs/005-detector-type.md
@@ -1,0 +1,45 @@
+# ADR 005: Detector Type
+
+This ADR documents the decision of adding the `type` parameter for detectors in the orchestrator config.
+
+## Motivation
+
+The guardrails orchestrator interfaces with different types of detectors. 
+Detectors of a given are type are compatible with only a subset of orchestrator endpoints.
+In order to reduce changes of misconfiguration, we need a way to map detectors to be used only with compatible endpoints.
+
+
+## Decision
+
+We decided to add the `type` parameter to the detectors configuration. 
+Possible values are `content`, `chat`, `generated` and `context`.
+Below is an example of detector configuration.
+
+```yaml
+detectors:
+    my_detector:
+        type: content # Options: content, chat, context, generated
+        service:
+            hostname: my-detector.com
+            port: 8080
+            tls: my_certs
+        chunker_id: my_chunker
+        default_threshold: 0.5
+```
+
+## Consequences
+
+1. Reduced misconfiguration risk.
+2. Future logic can be implemented for detectors of a particular type.
+3. `hostname` no longer needs the full URL, but only the actual hostname.
+4. If `tls` is provided, the `https` protocol is used. `http`, otherwise.
+5. Not including `type` results in a configuration validation error on orchestrator startup.
+6. Detector endpoints are automatically configured based on `type` as follows:
+    * `content` -> `/api/v1/text/contents`
+    * `chat` -> `/api/v1/text/context/chat`
+    * `context` -> `/api/v1/text/context/doc`
+    * `generated` -> `/api/v1/text/generation`
+
+## Status
+
+Accepted

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{create_http_clients, Error, HttpClient};
 use crate::{
-    config::ServiceConfig,
     health::{HealthCheck, HealthCheckResult, HealthProbe},
+    config::DetectorConfig,
     models::{DetectionResult, DetectorParams},
 };
 
@@ -49,7 +49,7 @@ impl HealthProbe for DetectorClient {
 
 #[cfg_attr(test, faux::methods)]
 impl DetectorClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
+    pub async fn new(default_port: u16, config: &[(String, DetectorConfig)]) -> Self {
         let clients: HashMap<String, HttpClient> = create_http_clients(default_port, config).await;
         Self { clients }
     }
@@ -77,7 +77,7 @@ impl DetectorClient {
         request: ContentAnalysisRequest,
     ) -> Result<Vec<Vec<ContentAnalysisResponse>>, Error> {
         let client = self.client(model_id)?;
-        let url = client.base_url().as_str();
+        let url = client.endpoint();
         let response = client
             .post(url)
             .header(DETECTOR_ID_HEADER_NAME, model_id)

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -24,7 +24,7 @@ use super::{create_http_clients, Error, HttpClient};
 use crate::{
     health::{HealthCheck, HealthCheckResult, HealthProbe},
     config::DetectorConfig,
-    models::DetectorParams,
+    models::{DetectionResult, DetectorParams},
 };
 
 const DETECTOR_ID_HEADER_NAME: &str = "detector-id";
@@ -68,12 +68,72 @@ impl DetectorClient {
         self.clients.iter()
     }
 
-    /// Invokes detector based on its type.
-    pub async fn invoke<T, U>(&self, model_id: &str, request: T) -> Result<U, Error>
-    where
-        T: serde::Serialize,
-        U: serde::de::DeserializeOwned,
-    {
+    // TODO: Use generics here, since the only thing that changes in comparison to generation_detection()
+    // is the "request" parameter and return types?
+    /// Invokes detectors implemented with the `/api/v1/text/contents` endpoint
+    pub async fn text_contents(
+        &self,
+        model_id: &str,
+        request: ContentAnalysisRequest,
+    ) -> Result<Vec<Vec<ContentAnalysisResponse>>, Error> {
+        let client = self.client(model_id)?;
+        let url = client.endpoint();
+        let response = client
+            .post(url)
+            .header(DETECTOR_ID_HEADER_NAME, model_id)
+            .json(&request)
+            .send()
+            .await?;
+        if response.status() == StatusCode::OK {
+            Ok(response.json().await?)
+        } else {
+            let code = response.status().as_u16();
+            let error = response
+                .json::<DetectorError>()
+                .await
+                .unwrap_or(DetectorError {
+                    code,
+                    message: "".into(),
+                });
+            Err(error.into())
+        }
+    }
+
+    /// Invokes detectors implemented with the `/api/v1/text/generation` endpoint
+    pub async fn text_generation(
+        &self,
+        model_id: &str,
+        request: GenerationDetectionRequest,
+    ) -> Result<Vec<DetectionResult>, Error> {
+        let client = self.client(model_id)?;
+        let url = client.endpoint();
+        let response = client
+            .post(url)
+            .header(DETECTOR_ID_HEADER_NAME, model_id)
+            .json(&request)
+            .send()
+            .await?;
+        if response.status() == StatusCode::OK {
+            Ok(response.json().await?)
+        } else {
+            let code = response.status().as_u16();
+            let error = response
+                .json::<DetectorError>()
+                .await
+                .unwrap_or(DetectorError {
+                    code,
+                    message: "".into(),
+                });
+            Err(error.into())
+        }
+    }
+
+    /// Invokes detectors implemented with the `/api/v1/text/context/doc` endpoint
+    pub async fn text_context_doc(
+        &self,
+        model_id: &str,
+        request: ContextDocsDetectionRequest,
+    ) -> Result<Vec<DetectionResult>, Error> {
         let client = self.client(model_id)?;
         let url = client.endpoint();
         let response = client

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -106,7 +106,7 @@ impl DetectorClient {
         request: GenerationDetectionRequest,
     ) -> Result<Vec<DetectionResult>, Error> {
         let client = self.client(model_id)?;
-        let url = client.base_url().as_str();
+        let url = client.endpoint();
         let response = client
             .post(url)
             .header(DETECTOR_ID_HEADER_NAME, model_id)
@@ -135,7 +135,7 @@ impl DetectorClient {
         request: ContextDocsDetectionRequest,
     ) -> Result<Vec<DetectionResult>, Error> {
         let client = self.client(model_id)?;
-        let url = client.base_url().as_str();
+        let url = client.endpoint();
         let response = client
             .post(url)
             .header(DETECTOR_ID_HEADER_NAME, model_id)

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{create_http_clients, Error, HttpClient};
 use crate::{
-    health::{HealthCheck, HealthCheckResult, HealthProbe},
     config::DetectorConfig,
+    health::{HealthCheck, HealthCheckResult, HealthProbe},
     models::{DetectionResult, DetectorParams},
 };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,6 +292,7 @@ detectors:
             port: 9000
         chunker_id: sentence-en
         default_threshold: 0.5
+        type: content
 tls: {}
         "#;
         let config: OrchestratorConfig = serde_yml::from_str(s).unwrap();
@@ -333,6 +334,7 @@ detectors:
             tls: detector
         chunker_id: sentence-en
         default_threshold: 0.5
+        type: content
 tls:
     detector:
         cert_path: /certs/client.pem
@@ -385,6 +387,7 @@ detectors:
             tls: detector
         chunker_id: sentence-en
         default_threshold: 0.5
+        type: content
 tls:
     detector:
         client_ca_cert_path: /certs/ca.pem
@@ -479,6 +482,7 @@ detectors:
             tls: notadetector
         chunker_id: sentence-en
         default_threshold: 0.5
+        type: content
 tls:
     detector:
         client_ca_cert_path: /certs/ca.pem
@@ -519,6 +523,7 @@ detectors:
             tls: detector
         chunker_id: sentence-fr
         default_threshold: 0.5
+        type: content
 tls:
     detector:
         client_ca_cert_path: /certs/ca.pem

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,17 @@ pub struct ChunkerConfig {
     pub service: ServiceConfig,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Default)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(rename_all = "lowercase")]
+pub enum DetectorType {
+    #[default]
+    Content,
+    Chat,
+    Context,
+    Generated,
+}
+
 /// Configuration for each detector
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct DetectorConfig {
@@ -128,6 +139,8 @@ pub struct DetectorConfig {
     pub chunker_id: String,
     /// Default threshold with which to filter detector results by score
     pub default_threshold: f64,
+    /// Type of detection this detector performs
+    pub r#type: DetectorType,
 }
 
 /// Overall orchestrator server configuration

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -195,7 +195,7 @@ async fn create_clients(
     let detector_config = config
         .detectors
         .iter()
-        .map(|(detector_id, config)| (detector_id.clone(), config.service.clone()))
+        .map(|(detector_id, config)| (detector_id.clone(), config.clone()))
         .collect::<Vec<_>>();
     let detector_client =
         DetectorClient::new(clients::DEFAULT_DETECTOR_PORT, &detector_config).await;

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error, info, instrument};
 
 use super::{get_chunker_ids, Context, Error, Orchestrator, StreamingClassificationWithGenTask};
 use crate::{
-    clients::detector::{ContentAnalysisRequest, ContentAnalysisResponse},
+    clients::detector::ContentAnalysisRequest,
     models::{
         ClassifiedGeneratedTextStreamResult, DetectorParams, GuardrailsTextGenerationParameters,
         InputWarning, InputWarningReason, TextGenTokenClassificationResults,
@@ -362,7 +362,7 @@ async fn detection_task(
                             debug!(%detector_id, ?request, "sending detector request");
                             match ctx
                                 .detector_client
-                                .invoke::<ContentAnalysisRequest, Vec<Vec<ContentAnalysisResponse>>>(&detector_id, request)
+                                .text_contents(&detector_id, request)
                                 .await
                                 .map_err(|error| Error::DetectorRequestFailed { id: detector_id.clone(), error }) {
                                     Ok(response) => {

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error, info, instrument};
 
 use super::{get_chunker_ids, Context, Error, Orchestrator, StreamingClassificationWithGenTask};
 use crate::{
-    clients::detector::ContentAnalysisRequest,
+    clients::detector::{ContentAnalysisRequest, ContentAnalysisResponse},
     models::{
         ClassifiedGeneratedTextStreamResult, DetectorParams, GuardrailsTextGenerationParameters,
         InputWarning, InputWarningReason, TextGenTokenClassificationResults,
@@ -362,7 +362,7 @@ async fn detection_task(
                             debug!(%detector_id, ?request, "sending detector request");
                             match ctx
                                 .detector_client
-                                .text_contents(&detector_id, request)
+                                .invoke::<ContentAnalysisRequest, Vec<Vec<ContentAnalysisResponse>>>(&detector_id, request)
                                 .await
                                 .map_err(|error| Error::DetectorRequestFailed { id: detector_id.clone(), error }) {
                                     Ok(response) => {

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -37,8 +37,7 @@ use crate::{
         unary::{input_detection_task, tokenize},
         UNSUITABLE_INPUT_MESSAGE,
     },
-    pb::caikit::runtime::chunkers,
-    pb::caikit_data_model::nlp::ChunkerTokenizationStreamResult,
+    pb::{caikit::runtime::chunkers, caikit_data_model::nlp::ChunkerTokenizationStreamResult},
 };
 
 pub type Chunk = ChunkerTokenizationStreamResult;

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -911,7 +911,7 @@ mod tests {
 
         faux::when!(mock_detector_client.text_contents(
             detector_id,
-            ContentAnalysisRequest::new(vec![first_sentence.clone(), second_sentence.clone()])
+            ContentAnalysisRequest::new(vec![first_sentence.clone(), second_sentence.clone()]),
         ))
         .once()
         .then_return(Ok(vec![
@@ -979,7 +979,7 @@ mod tests {
 
         faux::when!(mock_detector_client.text_contents(
             detector_id,
-            ContentAnalysisRequest::new(vec![sentence.clone()])
+            ContentAnalysisRequest::new(vec![sentence.clone()]),
         ))
         .once()
         .then_return(Err(clients::Error::Http {
@@ -1020,7 +1020,7 @@ mod tests {
 
         faux::when!(mock_detector_client.text_contents(
             detector_id,
-            ContentAnalysisRequest::new(vec![first_sentence.clone()])
+            ContentAnalysisRequest::new(vec![first_sentence.clone()]),
         ))
         .once()
         .then_return(Ok(vec![vec![]]));

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -518,14 +518,14 @@ pub async fn detect(
     let detector_id = detector_id.clone();
     let threshold = detector_params.threshold().unwrap_or(default_threshold);
     let contents: Vec<_> = chunks.iter().map(|chunk| chunk.text.clone()).collect();
-    let response: Vec<Vec<ContentAnalysisResponse>> = if contents.is_empty() {
+    let response = if contents.is_empty() {
         // skip detector call as contents is empty
         Vec::default()
     } else {
         let request = ContentAnalysisRequest::new(contents);
         debug!(%detector_id, ?request, "sending detector request");
         ctx.detector_client
-            .invoke(&detector_id, request)
+            .text_contents(&detector_id, request)
             .await
             .map_err(|error| {
                 debug!(%detector_id, ?error, "error received from detector");
@@ -572,14 +572,14 @@ pub async fn detect_content(
     let detector_id = detector_id.clone();
     let threshold = detector_params.threshold().unwrap_or(default_threshold);
     let contents: Vec<_> = chunks.iter().map(|chunk| chunk.text.clone()).collect();
-    let response: Vec<Vec<ContentAnalysisResponse>> = if contents.is_empty() {
+    let response = if contents.is_empty() {
         // skip detector call as contents is empty
         Vec::default()
     } else {
         let request = ContentAnalysisRequest::new(contents);
         debug!(%detector_id, ?request, "sending detector request");
         ctx.detector_client
-            .invoke(&detector_id, request)
+            .text_contents(&detector_id, request)
             .await
             .map_err(|error| {
                 debug!(%detector_id, ?error, "error received from detector");
@@ -634,9 +634,9 @@ pub async fn detect_for_generation(
     debug!(%detector_id, ?request, "sending generation detector request");
     let response = ctx
         .detector_client
-        .invoke(&detector_id, request)
+        .text_generation(&detector_id, request)
         .await
-        .map(|results: Vec<DetectionResult>| {
+        .map(|results| {
             results
                 .into_iter()
                 .filter(|detection| detection.score > threshold)
@@ -673,9 +673,9 @@ pub async fn detect_for_context(
     debug!(%detector_id, ?request, "sending context detector request");
     let response = ctx
         .detector_client
-        .invoke(&detector_id, request)
+        .text_context_doc(&detector_id, request)
         .await
-        .map(|results: Vec<DetectionResult>| {
+        .map(|results| {
             results
                 .into_iter()
                 .filter(|detection| detection.score > threshold)
@@ -909,7 +909,7 @@ mod tests {
             token_count: None,
         }];
 
-        faux::when!(mock_detector_client.invoke(
+        faux::when!(mock_detector_client.text_contents(
             detector_id,
             ContentAnalysisRequest::new(vec![first_sentence.clone(), second_sentence.clone()]),
         ))
@@ -977,7 +977,7 @@ mod tests {
             },
         };
 
-        faux::when!(mock_detector_client.invoke(
+        faux::when!(mock_detector_client.text_contents(
             detector_id,
             ContentAnalysisRequest::new(vec![sentence.clone()]),
         ))
@@ -1018,7 +1018,7 @@ mod tests {
             text: first_sentence.clone(),
         }];
 
-        faux::when!(mock_detector_client.invoke(
+        faux::when!(mock_detector_client.text_contents(
             detector_id,
             ContentAnalysisRequest::new(vec![first_sentence.clone()]),
         ))
@@ -1069,7 +1069,7 @@ mod tests {
             ),
         }];
 
-        faux::when!(mock_detector_client.invoke(
+        faux::when!(mock_detector_client.text_generation(
             detector_id,
             GenerationDetectionRequest::new(prompt.clone(), generated_text.clone())
         ))
@@ -1130,7 +1130,7 @@ mod tests {
 
         let expected_response: Vec<DetectionResult> = vec![];
 
-        faux::when!(mock_detector_client.invoke(
+        faux::when!(mock_detector_client.text_generation(
             detector_id,
             GenerationDetectionRequest::new(prompt.clone(), generated_text.clone())
         ))

--- a/tests/test.config.yaml
+++ b/tests/test.config.yaml
@@ -11,8 +11,9 @@ chunkers:
       port: 8085
 detectors:
   test_detector:
+    type: content
     service:
-      hostname: https://localhost/api/v1/text/contents
+      hostname: localhost
       port: 8000
     chunker_id: test_chunker
     default_threshold: 0.5


### PR DESCRIPTION
This addresses #165.

I'm opening this as I'd like to get some feedback on what I've done so far.

Missing tasks:
* [x] Add ADR
* [x] Either use generics or create a helper function for `text_contents(), `text_generation()` and `text_context_doc()` - as [faux has a limitation when dealing with generics](https://github.com/nrxus/faux/issues/18), I've rolled back this change and will work on it in a different PR.