### PR TITLE
Document  `/health` detector endpoint

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -216,6 +216,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /health:
+    get:
+      tags:
+        - Health
+      summary: Performs quick liveliness check of the detector service
+      operationId: health
+      responses:
+        '200':
+          description: Healthy
 components:
   schemas:
     ChatAnalysisHttpRequest:


### PR DESCRIPTION
This addresses #184 by documenting the `/health` endpoint for detectors.

Preview:
![image](https://github.com/user-attachments/assets/b7c08073-e640-472b-9f07-6a92e1dea3fd)
