### PR TITLE
:wrench: Update standalone chat detections API

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -146,20 +146,9 @@ paths:
                   Response Chat Analysis Unary Handler Api V1 Text Context Chat
                   Post
                 example:
-                  - message_index: 0
-                    results:
-                      - {
-                          "detection_type": "detection_type",
-                          "detection": "detection",
-                          "score": 0.999
-                        }
-                  - message_index: 1
-                    results:
-                      - {
-                          "detection_type": "detection_type",
-                          "detection": "detection",
-                          "score": 0.5
-                        }
+                  - detection: "detection_type"
+                    detection_type: "dummy_detector_type"
+                    score: 0.99
         '404':
           description: Resource Not Found
           content:
@@ -249,29 +238,6 @@ components:
         - messages
       title: ChatAnalysisHttpRequest
     ChatAnalysisResponse:
-      title: ChatAnalysisResponse
-      properties:
-        message_index:
-          oneOf:
-            - type: string # "all"
-            - type: integer # index
-          title: Index of message
-        results:
-          title: Detection results
-          type: array
-          items:
-            $ref: '#/components/schemas/ChatAnalysisDetection'
-      required:
-        - message_index
-      example:
-        message_index: 0
-        results:
-          - {
-              "detection_type": "detection_type",
-              "detection": "detection",
-              "score": 0.999
-            }
-    ChatAnalysisDetection:
       properties:
         detection:
           type: string
@@ -296,7 +262,7 @@ components:
         - detection
         - detection_type
         - score
-      title: ChatAnalysisDetection
+      title: ChatAnalysisResponse
     ContextAnalysisHttpRequest:
       properties:
         content:

--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -187,7 +187,7 @@ paths:
     post:
       tags:
         - Task - Detection
-      summary: Detection task on chat messages
+      summary: Detection task on entire history of chat messages
       operationId: >-
         api_v2_detection_text_chat_unary_handler
       requestBody:
@@ -450,8 +450,19 @@ components:
         detections:
           type: array
           items:
-            $ref: '#/components/schemas/MessageDetections'
-          title: Detections on input to chat completions
+            type: object
+            title: Detection Object
+            properties:
+              detection_type:
+                type: string
+                title: Detection Type
+              detection:
+                type: string
+                title: Detection
+              score:
+                type: number
+                title: Score
+          title: Detections on entire history of chat messages
       title: Chat Detection Response
       required: ["detections"]
     


### PR DESCRIPTION
Related to updates for detections on chat completions and ADR proposed in #209 

This enables detections on chat messages in a standalone detections orchestrator endpoint, reusing the openAI schema for messages. This endpoint will focus on allowing for the concept of detectors running on entire message histories (e.g. multiple roles and content).

The corresponding chat detector endpoint has been updated as well.

For: #195 