### PR TITLE
Fix the config path CLI arg's corresponding env variable to match the documentation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,11 @@ struct Args {
     health_http_port: u16,
     #[clap(long, env)]
     json_output: bool,
-    #[clap(default_value = "config/config.yaml", long, env)]
+    #[clap(
+        default_value = "config/config.yaml",
+        long,
+        env = "ORCHESTRATOR_CONFIG"
+    )]
     config_path: PathBuf,
     #[clap(long, env)]
     tls_cert_path: Option<PathBuf>,


### PR DESCRIPTION
The `--config-path` CLI arg does not specify the name of the corresponding env var so it defaults to `CONFIG_PATH`. The Dockerfile and playbooks (https://github.ibm.com/ai-foundation/watson-fm-playbooks/blob/9708fbe8fe7981101e0bd8afdc4702435c3bf5b6/assets/guardrails-deploy/devstage-orchestr8-tls.yaml#L78) expect to be able to set the config path with the env var `ORCHESTRATOR_CONFIG`. 