### PR TITLE
Client optional health port configuration

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,8 @@ generation:
     provider: tgis # tgis or nlp
     service:
         hostname: localhost
-        port: 8033
+        port: 8033 # Optionally, the default value of the port (dependent on the client type) can be overridden
+        health_port: 8035 # Optionally, the using `port` for the health endpoint can be overridden
 # Any chunker servers that will be used by any detectors
 chunkers:
     # Chunker ID/name

--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -73,9 +73,9 @@ impl HealthProbe for ChunkerClient {
 
 #[cfg_attr(test, faux::methods)]
 impl ChunkerClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
-        let clients = create_grpc_clients(default_port, config, ChunkersServiceClient::new).await;
-        let health_clients = create_grpc_clients(default_port, config, HealthClient::new).await;
+    pub async fn new(config: &[(String, ServiceConfig)]) -> Self {
+        let clients = create_grpc_clients(config, ChunkersServiceClient::new).await;
+        let health_clients = create_grpc_clients(config, HealthClient::new).await;
         Self {
             clients,
             health_clients,

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -49,8 +49,8 @@ impl HealthProbe for DetectorClient {
 
 #[cfg_attr(test, faux::methods)]
 impl DetectorClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
-        let clients: HashMap<String, HttpClient> = create_http_clients(default_port, config).await;
+    pub async fn new(config: &[(String, ServiceConfig)]) -> Self {
+        let clients: HashMap<String, HttpClient> = create_http_clients(config).await;
         Self { clients }
     }
 

--- a/src/clients/nlp.rs
+++ b/src/clients/nlp.rs
@@ -70,9 +70,9 @@ impl HealthProbe for NlpClient {
 
 #[cfg_attr(test, faux::methods)]
 impl NlpClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
-        let clients = create_grpc_clients(default_port, config, NlpServiceClient::new).await;
-        let health_clients = create_grpc_clients(default_port, config, HealthClient::new).await;
+    pub async fn new(config: &[(String, ServiceConfig)]) -> Self {
+        let clients = create_grpc_clients(config, NlpServiceClient::new).await;
+        let health_clients = create_grpc_clients(config, HealthClient::new).await;
         Self {
             clients,
             health_clients,

--- a/src/clients/tgis.rs
+++ b/src/clients/tgis.rs
@@ -76,8 +76,8 @@ impl HealthProbe for TgisClient {
 
 #[cfg_attr(test, faux::methods)]
 impl TgisClient {
-    pub async fn new(default_port: u16, config: &[(String, ServiceConfig)]) -> Self {
-        let clients = create_grpc_clients(default_port, config, GenerationServiceClient::new).await;
+    pub async fn new(config: &[(String, ServiceConfig)]) -> Self {
+        let clients = create_grpc_clients(config, GenerationServiceClient::new).await;
         Self { clients }
     }
 

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 use crate::{
     clients::{
-        self, detector::ContextType, ChunkerClient, DetectorClient, GenerationClient, NlpClient,
+        detector::ContextType, ChunkerClient, DetectorClient, GenerationClient, NlpClient,
         TgisClient, COMMON_ROUTER_KEY,
     },
     config::{GenerationProvider, OrchestratorConfig},
@@ -169,18 +169,18 @@ async fn create_clients(
     let generation_client = match &config.generation {
         Some(generation) => match &generation.provider {
             GenerationProvider::Tgis => {
-                let client = TgisClient::new(
-                    clients::DEFAULT_TGIS_PORT,
-                    &[(COMMON_ROUTER_KEY.to_string(), generation.service.clone())],
-                )
+                let client = TgisClient::new(&[(
+                    COMMON_ROUTER_KEY.to_string(),
+                    generation.service.clone(),
+                )])
                 .await;
                 GenerationClient::tgis(client)
             }
             GenerationProvider::Nlp => {
-                let client = NlpClient::new(
-                    clients::DEFAULT_CAIKIT_NLP_PORT,
-                    &[(COMMON_ROUTER_KEY.to_string(), generation.service.clone())],
-                )
+                let client = NlpClient::new(&[(
+                    COMMON_ROUTER_KEY.to_string(),
+                    generation.service.clone(),
+                )])
                 .await;
                 GenerationClient::nlp(client)
             }
@@ -195,7 +195,7 @@ async fn create_clients(
             .collect::<Vec<_>>(),
         None => vec![],
     };
-    let chunker_client = ChunkerClient::new(clients::DEFAULT_CHUNKER_PORT, &chunker_config).await;
+    let chunker_client = ChunkerClient::new(&chunker_config).await;
 
     let detector_config = config
         .detectors
@@ -203,7 +203,7 @@ async fn create_clients(
         .map(|(detector_id, config)| (detector_id.clone(), config.service.clone()))
         .collect::<Vec<_>>();
     let detector_client =
-        DetectorClient::new(clients::DEFAULT_DETECTOR_PORT, &detector_config).await;
+        DetectorClient::new(&detector_config).await;
 
     (generation_client, chunker_client, detector_client)
 }


### PR DESCRIPTION
This PR is for resolving https://github.ibm.com/ai-foundation/watson-fm-stack-tracker/issues/1373, which is resulting from detectors now using 8001 for health check while still using 8000 for the main port.

This PR enables health ports to be optionally configured as part of the `service` of a client in the orchestrator config. If omitted, the health port will default to the value of the main port for that client (which itself may default). Alongside adding this, the PR does a minor refactor of how the service configs are passed down, since there is currently complexity in the orchestrator for client creation that could have been caught earlier as part of config loading/validation. 

(Note that as a follow up to this, we can also be resolving client tls cert paths before client creation, but that is outside the scope of this PR.)