### PR TITLE
Chat standalone endpoint

### DIFF
--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use super::{DetectorError, DEFAULT_PORT, DETECTOR_ID_HEADER_NAME};
 use crate::{
-    clients::{create_http_client, Client, Error, HttpClient},
+    clients::{create_http_client, openai::Message, Client, Error, HttpClient},
     config::ServiceConfig,
     health::HealthCheckResult,
     models::{DetectionResult, DetectorParams},
@@ -85,13 +85,13 @@ impl Client for TextChatDetectorClient {
 #[derive(Debug, Serialize)]
 pub struct ChatDetectionRequest {
     /// Chat messages to run detection on
-    pub messages: Vec<String>,
+    pub messages: Vec<Message>,
 
     pub detector_params: DetectorParams,
 }
 
 impl ChatDetectionRequest {
-    pub fn new(messages: Vec<String>, detector_params: DetectorParams) -> Self {
+    pub fn new(messages: Vec<Message>, detector_params: DetectorParams) -> Self {
         Self {
             messages,
             detector_params,

--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -7,7 +7,7 @@ use crate::{
     clients::{create_http_client, Client, Error, HttpClient},
     config::ServiceConfig,
     health::HealthCheckResult,
-    models::DetectionResult,
+    models::{DetectionResult, DetectorParams},
 };
 
 #[cfg_attr(test, faux::create)]
@@ -86,10 +86,15 @@ impl Client for TextChatDetectorClient {
 pub struct ChatDetectionRequest {
     /// Chat messages to run detection on
     pub messages: Vec<String>,
+
+    pub detector_params: DetectorParams,
 }
 
 impl ChatDetectionRequest {
-    pub fn new(messages: Vec<String>) -> Self {
-        Self { messages }
+    pub fn new(messages: Vec<String>, detector_params: DetectorParams) -> Self {
+        Self {
+            messages,
+            detector_params,
+        }
     }
 }

--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -39,14 +39,17 @@ impl TextChatDetectorClient {
         headers: HeaderMap,
     ) -> Result<Vec<DetectionResult>, Error> {
         let url = self.client.base_url().join("/api/v1/text/chat").unwrap();
-        let response = self
+        let request = self
             .client
             .post(url)
             .headers(headers)
             .header(DETECTOR_ID_HEADER_NAME, model_id)
-            .json(&request)
-            .send()
-            .await?;
+            .json(&request);
+
+        tracing::debug!("Request being sent to chat detector: {:?}", request);
+        let response = request.send().await?;
+        tracing::debug!("Response received from chat detector: {:?}", response);
+
         if response.status() == StatusCode::OK {
             Ok(response.json().await?)
         } else {

--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use super::{DetectorError, DEFAULT_PORT, DETECTOR_ID_HEADER_NAME};
 use crate::{
-    clients::{create_http_client, openai::Message, Client, Error, HttpClient},
+    clients::{create_http_client, Client, Error, HttpClient},
     config::ServiceConfig,
     health::HealthCheckResult,
     models::DetectionResult,
@@ -85,11 +85,11 @@ impl Client for TextChatDetectorClient {
 #[derive(Debug, Serialize)]
 pub struct ChatDetectionRequest {
     /// Chat messages to run detection on
-    pub messages: Vec<Message>,
+    pub messages: Vec<String>,
 }
 
 impl ChatDetectionRequest {
-    pub fn new(messages: Vec<Message>) -> Self {
+    pub fn new(messages: Vec<String>) -> Self {
         Self { messages }
     }
 }

--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -10,6 +10,8 @@ use crate::{
     models::{DetectionResult, DetectorParams},
 };
 
+const CHAT_DETECTOR_ENDPOINT: &str = "/api/v1/text/chat";
+
 #[cfg_attr(test, faux::create)]
 #[derive(Clone)]
 pub struct TextChatDetectorClient {
@@ -38,7 +40,7 @@ impl TextChatDetectorClient {
         request: ChatDetectionRequest,
         headers: HeaderMap,
     ) -> Result<Vec<DetectionResult>, Error> {
-        let url = self.client.base_url().join("/api/v1/text/chat").unwrap();
+        let url = self.client.base_url().join(CHAT_DETECTOR_ENDPOINT).unwrap();
         let request = self
             .client
             .post(url)

--- a/src/models.rs
+++ b/src/models.rs
@@ -964,10 +964,13 @@ impl ChatDetectionHttpRequest {
             return Err(ValidationError::Required("messages".into()));
         }
 
-        // validate messages
-        self.validate_messages()?;
+        Ok(())
+    }
 
-        // Validate detector params
+    /// Validates for the "/api/v1/text/chat" endpoint.
+    pub fn validate_for_text(&self) -> Result<(), ValidationError> {
+        self.validate()?;
+        self.validate_messages()?;
         validate_detector_params(&self.detectors)?;
 
         Ok(())

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,7 +22,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    clients::detector::{ContentAnalysisResponse, ContextType},
+    clients::{
+        self,
+        detector::{ContentAnalysisResponse, ContextType},
+    },
     health::HealthCheckCache,
     pb,
 };
@@ -946,7 +949,7 @@ pub struct ChatDetectionHttpRequest {
     pub detectors: HashMap<String, DetectorParams>,
 
     // The list of messages to run detections on.
-    pub messages: Vec<String>,
+    pub messages: Vec<clients::openai::Message>,
 }
 
 impl ChatDetectionHttpRequest {

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,10 +22,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    clients::{
-        self,
-        detector::{ContentAnalysisResponse, ContextType},
-    },
+    clients::detector::{ContentAnalysisResponse, ContextType},
     health::HealthCheckCache,
     pb,
 };
@@ -949,7 +946,7 @@ pub struct ChatDetectionHttpRequest {
     pub detectors: HashMap<String, DetectorParams>,
 
     // The list of messages to run detections on.
-    pub messages: Vec<clients::openai::Message>,
+    pub messages: Vec<String>,
 }
 
 impl ChatDetectionHttpRequest {

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -30,7 +30,6 @@ use uuid::Uuid;
 use crate::{
     clients::{
         chunker::ChunkerClient,
-        self,
         detector::{
             text_context_doc::ContextType, TextChatDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
@@ -393,7 +392,7 @@ pub struct ChatDetectionTask {
     pub detectors: HashMap<String, DetectorParams>,
 
     // Messages to run detection on
-    pub messages: Vec<clients::openai::Message>,
+    pub messages: Vec<String>,
 
     // Headermap
     pub headers: HeaderMap,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -29,6 +29,7 @@ use uuid::Uuid;
 
 use crate::{
     clients::{
+        self,
         chunker::ChunkerClient,
         detector::{
             text_context_doc::ContextType, TextChatDetectorClient, TextContextDocDetectorClient,
@@ -392,7 +393,7 @@ pub struct ChatDetectionTask {
     pub detectors: HashMap<String, DetectorParams>,
 
     // Messages to run detection on
-    pub messages: Vec<String>,
+    pub messages: Vec<clients::openai::Message>,
 
     // Headermap
     pub headers: HeaderMap,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 use crate::{
     clients::{
         chunker::ChunkerClient,
+        self,
         detector::{
             text_context_doc::ContextType, TextChatDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
@@ -40,9 +41,9 @@ use crate::{
     config::{DetectorType, GenerationProvider, OrchestratorConfig},
     health::HealthCheckCache,
     models::{
-        ContextDocsHttpRequest, DetectionOnGeneratedHttpRequest, DetectorParams,
-        GenerationWithDetectionHttpRequest, GuardrailsConfig, GuardrailsHttpRequest,
-        GuardrailsTextGenerationParameters, TextContentDetectionHttpRequest,
+        ChatDetectionHttpRequest, ContextDocsHttpRequest, DetectionOnGeneratedHttpRequest,
+        DetectorParams, GenerationWithDetectionHttpRequest, GuardrailsConfig,
+        GuardrailsHttpRequest, GuardrailsTextGenerationParameters, TextContentDetectionHttpRequest,
     },
 };
 
@@ -377,6 +378,33 @@ impl ContextDocsDetectionTask {
             context_type: request.context_type,
             context: request.context,
             detectors: request.detectors,
+            headers,
+        }
+    }
+}
+
+/// Task for the /api/v2/text/detection/chat endpoint
+#[derive(Debug)]
+pub struct ChatDetectionTask {
+    /// Request unique identifier
+    pub request_id: Uuid,
+
+    /// Detectors configuration
+    pub detectors: HashMap<String, DetectorParams>,
+
+    // Messages to run detection on
+    pub messages: Vec<clients::openai::Message>,
+
+    // Headermap
+    pub headers: HeaderMap,
+}
+
+impl ChatDetectionTask {
+    pub fn new(request_id: Uuid, request: ChatDetectionHttpRequest, headers: HeaderMap) -> Self {
+        Self {
+            request_id,
+            detectors: request.detectors,
+            messages: request.messages,
             headers,
         }
     }

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -500,7 +500,7 @@ impl Orchestrator {
             // Task cancelled or panicked
             Err(error) => {
                 let error = error.into();
-                error!(request_id = ?task.request_id, %error, "detection on chat content task failed");
+                error!(request_id = ?task.request_id, %error, "detection task on chat failed");
                 Err(error)
             }
         }

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -786,7 +786,7 @@ pub async fn detect_for_chat(
                 .default_threshold,
         ),
     );
-    let request = ChatDetectionRequest::new(messages.clone());
+    let request = ChatDetectionRequest::new(messages.clone(), detector_params.clone());
     debug!(%detector_id, ?request, "sending chat detector request");
     let client = ctx
         .clients

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -494,7 +494,7 @@ impl Orchestrator {
             Ok(Ok(result)) => Ok(result),
             // Task failed, return error propagated from child task that failed
             Ok(Err(error)) => {
-                error!(request_id = ?task.request_id, %error, "detection on chat content task failed");
+                error!(request_id = ?task.request_id, %error, "detection task on chat failed");
                 Err(error)
             }
             // Task cancelled or panicked

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -25,7 +25,7 @@ use futures::{
 use tracing::{debug, error, info, instrument};
 
 use super::{
-    apply_masks, get_chunker_ids, Chunk, ClassificationWithGenTask, Context,
+    apply_masks, get_chunker_ids, ChatDetectionTask, Chunk, ClassificationWithGenTask, Context,
     ContextDocsDetectionTask, DetectionOnGenerationTask, Error, GenerationWithDetectionTask,
     Orchestrator, TextContentDetectionTask,
 };
@@ -33,17 +33,20 @@ use crate::{
     clients::{
         chunker::{tokenize_whole_doc, ChunkerClient, DEFAULT_CHUNKER_ID},
         detector::{
-            ContentAnalysisRequest, ContentAnalysisResponse, ContextDocsDetectionRequest,
-            ContextType, GenerationDetectionRequest, TextContentsDetectorClient,
-            TextContextDocDetectorClient, TextGenerationDetectorClient,
+            ChatDetectionRequest, ContentAnalysisRequest, ContentAnalysisResponse,
+            ContextDocsDetectionRequest, ContextType, GenerationDetectionRequest,
+            TextChatDetectorClient, TextContentsDetectorClient, TextContextDocDetectorClient,
+            TextGenerationDetectorClient,
         },
+        openai::Message,
         GenerationClient,
     },
     models::{
-        ClassifiedGeneratedTextResult, ContextDocsResult, DetectionOnGenerationResult,
-        DetectionResult, DetectorParams, GenerationWithDetectionResult,
-        GuardrailsTextGenerationParameters, InputWarning, InputWarningReason,
-        TextContentDetectionResult, TextGenTokenClassificationResults, TokenClassificationResult,
+        ChatDetectionResult, ClassifiedGeneratedTextResult, ContextDocsResult,
+        DetectionOnGenerationResult, DetectionResult, DetectorParams,
+        GenerationWithDetectionResult, GuardrailsTextGenerationParameters, InputWarning,
+        InputWarningReason, TextContentDetectionResult, TextGenTokenClassificationResults,
+        TokenClassificationResult,
     },
     orchestrator::UNSUITABLE_INPUT_MESSAGE,
     pb::caikit::runtime::chunkers,
@@ -447,6 +450,61 @@ impl Orchestrator {
             }
         }
     }
+
+    /// Handles detections on chat messages (without performing generation)
+    pub async fn handle_chat_detection(
+        &self,
+        task: ChatDetectionTask,
+    ) -> Result<ChatDetectionResult, Error> {
+        info!(
+            request_id = ?task.request_id,
+            detectors = ?task.detectors,
+            "handling detection on chat content task"
+        );
+        let ctx = self.ctx.clone();
+        let headers = task.headers;
+
+        let task_handle = tokio::spawn(async move {
+            // call detection
+            let detections = try_join_all(
+                task.detectors
+                    .iter()
+                    .map(|(detector_id, detector_params)| {
+                        let ctx = ctx.clone();
+                        let detector_id = detector_id.clone();
+                        let detector_params = detector_params.clone();
+                        let messages = task.messages.clone();
+                        let headers = headers.clone();
+                        async {
+                            detect_for_chat(ctx, detector_id, detector_params, messages, headers)
+                                .await
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+            Ok(ChatDetectionResult { detections })
+        });
+        match task_handle.await {
+            // Task completed successfully
+            Ok(Ok(result)) => Ok(result),
+            // Task failed, return error propagated from child task that failed
+            Ok(Err(error)) => {
+                error!(request_id = ?task.request_id, %error, "detection on chat content task failed");
+                Err(error)
+            }
+            // Task cancelled or panicked
+            Err(error) => {
+                let error = error.into();
+                error!(request_id = ?task.request_id, %error, "detection on chat content task failed");
+                Err(error)
+            }
+        }
+    }
 }
 
 /// Handles input detection task.
@@ -708,6 +766,47 @@ pub async fn detect_for_generation(
             error,
         })?;
     debug!(%detector_id, ?response, "received generation detector response");
+    Ok::<Vec<DetectionResult>, Error>(response)
+}
+
+/// Calls a detector that implements the /api/v1/text/chat endpoint
+pub async fn detect_for_chat(
+    ctx: Arc<Context>,
+    detector_id: String,
+    detector_params: DetectorParams,
+    messages: Vec<Message>,
+    headers: HeaderMap,
+) -> Result<Vec<DetectionResult>, Error> {
+    let detector_id = detector_id.clone();
+    let threshold = detector_params.threshold().unwrap_or(
+        detector_params.threshold().unwrap_or(
+            ctx.config
+                .detectors
+                .get(&detector_id)
+                .ok_or_else(|| Error::DetectorNotFound(detector_id.clone()))?
+                .default_threshold,
+        ),
+    );
+    let request = ChatDetectionRequest::new(messages.clone());
+    debug!(%detector_id, ?request, "sending chat detector request");
+    let client = ctx
+        .clients
+        .get_as::<TextChatDetectorClient>(&detector_id)
+        .unwrap();
+    let response = client
+        .text_chat(&detector_id, request, headers)
+        .await
+        .map(|results| {
+            results
+                .into_iter()
+                .filter(|detection| detection.score > threshold)
+                .collect()
+        })
+        .map_err(|error| Error::DetectorRequestFailed {
+            id: detector_id.clone(),
+            error,
+        })?;
+    debug!(%detector_id, ?response, "received chat detector response");
     Ok::<Vec<DetectionResult>, Error>(response)
 }
 

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -38,7 +38,6 @@ use crate::{
             TextChatDetectorClient, TextContentsDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
         },
-        openai::Message,
         GenerationClient,
     },
     models::{
@@ -774,7 +773,7 @@ pub async fn detect_for_chat(
     ctx: Arc<Context>,
     detector_id: String,
     detector_params: DetectorParams,
-    messages: Vec<Message>,
+    messages: Vec<String>,
     headers: HeaderMap,
 ) -> Result<Vec<DetectionResult>, Error> {
     let detector_id = detector_id.clone();

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -38,6 +38,7 @@ use crate::{
             TextChatDetectorClient, TextContentsDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
         },
+        openai::Message,
         GenerationClient,
     },
     models::{
@@ -773,7 +774,7 @@ pub async fn detect_for_chat(
     ctx: Arc<Context>,
     detector_id: String,
     detector_params: DetectorParams,
-    messages: Vec<String>,
+    messages: Vec<Message>,
     headers: HeaderMap,
 ) -> Result<Vec<DetectionResult>, Error> {
     let detector_id = detector_id.clone();

--- a/src/server.rs
+++ b/src/server.rs
@@ -442,6 +442,7 @@ async fn detect_chat(
 ) -> Result<impl IntoResponse, Error> {
     let request_id = Uuid::new_v4();
     request.validate()?;
+    let headers = filter_headers(&state.orchestrator.config().passthrough_headers, headers);
     let task = ChatDetectionTask::new(request_id, request, headers);
     match state.orchestrator.handle_chat_detection(task).await {
         Ok(response) => Ok(Json(response).into_response()),

--- a/src/server.rs
+++ b/src/server.rs
@@ -441,7 +441,7 @@ async fn detect_chat(
     WithRejection(Json(request), _): WithRejection<Json<models::ChatDetectionHttpRequest>, Error>,
 ) -> Result<impl IntoResponse, Error> {
     let request_id = Uuid::new_v4();
-    request.validate()?;
+    request.validate_for_text()?;
     let headers = filter_headers(&state.orchestrator.config().passthrough_headers, headers);
     let task = ChatDetectionTask::new(request_id, request, headers);
     match state.orchestrator.handle_chat_detection(task).await {


### PR DESCRIPTION
This addresses #210. Messages can be either strings or text content types.

Tests performed:
1. Accepts string messages
2. Accepts text content type messages
3. Rejects image content type messages
4. Propagates 404 messages from detectors.
5. Propagates 503 messages from detectors.
6. Propagates 422 messages from detectors.
7. Returns error 500 when detectors return messages not compliant with [the API](https://foundation-model-stack.github.io/fms-guardrails-orchestrator/?urls.primaryName=Detector+API#/default/chat_analysis_unary_handler_api_v1_text_chat_post).