### PR TITLE
:bug: Fix threshold getting passed through beyond orchestrator proces…

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -54,8 +54,8 @@ impl DetectorParams {
     }
 
     /// Threshold to filter detector results by score.
-    pub fn threshold(&self) -> Option<f64> {
-        self.0.get("threshold").and_then(|v| v.as_f64())
+    pub fn threshold(&mut self) -> Option<f64> {
+        self.0.remove("threshold").and_then(|v| v.as_f64())
     }
 }
 
@@ -1272,9 +1272,11 @@ mod tests {
         {
             "threshold": 0.2
         }"#;
-        let value: DetectorParams = serde_json::from_str(value_json)?;
+        let mut value: DetectorParams = serde_json::from_str(value_json)?;
         assert_eq!(value.threshold(), Some(0.2));
-        let value = DetectorParams::new();
+        assert!(!value.contains_key("threshold"));
+        let mut value = DetectorParams::new();
+        assert!(!value.contains_key("threshold"));
         assert_eq!(value.threshold(), None);
         Ok(())
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -54,7 +54,7 @@ impl DetectorParams {
     }
 
     /// Threshold to filter detector results by score.
-    pub fn threshold(&mut self) -> Option<f64> {
+    pub fn pop_threshold(&mut self) -> Option<f64> {
         self.0.remove("threshold").and_then(|v| v.as_f64())
     }
 }
@@ -1273,11 +1273,11 @@ mod tests {
             "threshold": 0.2
         }"#;
         let mut value: DetectorParams = serde_json::from_str(value_json)?;
-        assert_eq!(value.threshold(), Some(0.2));
+        assert_eq!(value.pop_threshold(), Some(0.2));
         assert!(!value.contains_key("threshold"));
         let mut value = DetectorParams::new();
         assert!(!value.contains_key("threshold"));
-        assert_eq!(value.threshold(), None);
+        assert_eq!(value.pop_threshold(), None);
         Ok(())
     }
 }

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -267,6 +267,8 @@ async fn streaming_output_detection_task(
     debug!("spawning detection tasks");
     let mut detection_streams = Vec::with_capacity(detectors.len());
     for (detector_id, detector_params) in detectors.iter() {
+        // Create a mutable copy of the parameters, so that we can modify it based on processing
+        let mut detector_params = detector_params.clone();
         let detector_id = detector_id.to_string();
         let chunker_id = ctx.config.get_chunker_id(&detector_id).unwrap();
 

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -278,7 +278,7 @@ async fn streaming_output_detection_task(
 
         // Get the default threshold to use if threshold is not provided by the user
         let default_threshold = detector_config.default_threshold;
-        let threshold = detector_params.threshold().unwrap_or(default_threshold);
+        let threshold = detector_params.pop_threshold().unwrap_or(default_threshold);
 
         // Create detection stream
         let (detector_tx, detector_rx) = mpsc::channel(1024);

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -622,7 +622,7 @@ pub async fn detect(
     headers: HeaderMap,
 ) -> Result<Vec<TokenClassificationResult>, Error> {
     let detector_id = detector_id.clone();
-    let threshold = detector_params.threshold().unwrap_or(default_threshold);
+    let threshold = detector_params.pop_threshold().unwrap_or(default_threshold);
     let contents: Vec<_> = chunks.iter().map(|chunk| chunk.text.clone()).collect();
     let response = if contents.is_empty() {
         // skip detector call as contents is empty
@@ -681,7 +681,7 @@ pub async fn detect_content(
     headers: HeaderMap,
 ) -> Result<Vec<ContentAnalysisResponse>, Error> {
     let detector_id = detector_id.clone();
-    let threshold = detector_params.threshold().unwrap_or(default_threshold);
+    let threshold = detector_params.pop_threshold().unwrap_or(default_threshold);
     let contents: Vec<_> = chunks.iter().map(|chunk| chunk.text.clone()).collect();
     let response = if contents.is_empty() {
         // skip detector call as contents is empty
@@ -737,8 +737,8 @@ pub async fn detect_for_generation(
     headers: HeaderMap,
 ) -> Result<Vec<DetectionResult>, Error> {
     let detector_id = detector_id.clone();
-    let threshold = detector_params.threshold().unwrap_or(
-        detector_params.threshold().unwrap_or(
+    let threshold = detector_params.pop_threshold().unwrap_or(
+        detector_params.pop_threshold().unwrap_or(
             ctx.config
                 .detectors
                 .get(&detector_id)
@@ -778,8 +778,8 @@ pub async fn detect_for_chat(
     headers: HeaderMap,
 ) -> Result<Vec<DetectionResult>, Error> {
     let detector_id = detector_id.clone();
-    let threshold = detector_params.threshold().unwrap_or(
-        detector_params.threshold().unwrap_or(
+    let threshold = detector_params.pop_threshold().unwrap_or(
+        detector_params.pop_threshold().unwrap_or(
             ctx.config
                 .detectors
                 .get(&detector_id)
@@ -821,8 +821,8 @@ pub async fn detect_for_context(
     headers: HeaderMap,
 ) -> Result<Vec<DetectionResult>, Error> {
     let detector_id = detector_id.clone();
-    let threshold = detector_params.threshold().unwrap_or(
-        detector_params.threshold().unwrap_or(
+    let threshold = detector_params.pop_threshold().unwrap_or(
+        detector_params.pop_threshold().unwrap_or(
             ctx.config
                 .detectors
                 .get(&detector_id)

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -617,7 +617,7 @@ pub async fn detect(
     ctx: Arc<Context>,
     detector_id: String,
     default_threshold: f64,
-    detector_params: DetectorParams,
+    mut detector_params: DetectorParams,
     chunks: Vec<Chunk>,
     headers: HeaderMap,
 ) -> Result<Vec<TokenClassificationResult>, Error> {
@@ -676,7 +676,7 @@ pub async fn detect_content(
     ctx: Arc<Context>,
     detector_id: String,
     default_threshold: f64,
-    detector_params: DetectorParams,
+    mut detector_params: DetectorParams,
     chunks: Vec<Chunk>,
     headers: HeaderMap,
 ) -> Result<Vec<ContentAnalysisResponse>, Error> {
@@ -731,7 +731,7 @@ pub async fn detect_content(
 pub async fn detect_for_generation(
     ctx: Arc<Context>,
     detector_id: String,
-    detector_params: DetectorParams,
+    mut detector_params: DetectorParams,
     prompt: String,
     generated_text: String,
     headers: HeaderMap,
@@ -773,7 +773,7 @@ pub async fn detect_for_generation(
 pub async fn detect_for_chat(
     ctx: Arc<Context>,
     detector_id: String,
-    detector_params: DetectorParams,
+    mut detector_params: DetectorParams,
     messages: Vec<Message>,
     headers: HeaderMap,
 ) -> Result<Vec<DetectionResult>, Error> {
@@ -814,7 +814,7 @@ pub async fn detect_for_chat(
 pub async fn detect_for_context(
     ctx: Arc<Context>,
     detector_id: String,
-    detector_params: DetectorParams,
+    mut detector_params: DetectorParams,
     content: String,
     context_type: ContextType,
     context: Vec<String>,


### PR DESCRIPTION
### Description

Remove `threshold` parameter as soon as it gets fetched.

Closes: https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/234