### PR TITLE
Implement Chat Completions API

### DIFF
--- a/src/clients/openai.rs
+++ b/src/clients/openai.rs
@@ -58,9 +58,9 @@ impl OpenAiClient {
     #[instrument(skip_all, fields(request.model))]
     pub async fn chat_completions(
         &self,
-        request: ChatCompletionRequest,
+        request: ChatCompletionsRequest,
         headers: HeaderMap,
-    ) -> Result<ChatCompletionResponse, Error> {
+    ) -> Result<ChatCompletionsResponse, Error> {
         let url = self.client.base_url().join("/v1/chat/completions").unwrap();
         let headers = with_traceparent_header(headers);
         let stream = request.stream.unwrap_or_default();
@@ -94,7 +94,7 @@ impl OpenAiClient {
                     }
                 }
             });
-            Ok(ChatCompletionResponse::Streaming(rx))
+            Ok(ChatCompletionsResponse::Streaming(rx))
         } else {
             let response = self
                 .client
@@ -136,19 +136,19 @@ impl Client for OpenAiClient {
 }
 
 #[derive(Debug)]
-pub enum ChatCompletionResponse {
+pub enum ChatCompletionsResponse {
     Unary(ChatCompletion),
     Streaming(mpsc::Receiver<Result<sse::Event, Infallible>>),
 }
 
-impl From<ChatCompletion> for ChatCompletionResponse {
+impl From<ChatCompletion> for ChatCompletionsResponse {
     fn from(value: ChatCompletion) -> Self {
         Self::Unary(value)
     }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct ChatCompletionRequest {
+pub struct ChatCompletionsRequest {
     /// A list of messages comprising the conversation so far.
     pub messages: Vec<Message>,
     /// ID of the model to use.

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -17,7 +17,7 @@
 
 pub mod errors;
 pub use errors::Error;
-pub mod chat_completions;
+pub mod chat_completions_detection;
 pub mod streaming;
 pub mod unary;
 
@@ -36,7 +36,7 @@ use crate::{
             text_context_doc::ContextType, TextChatDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
         },
-        openai::{ChatCompletionRequest, OpenAiClient},
+        openai::{ChatCompletionsRequest, OpenAiClient},
         ClientMap, GenerationClient, NlpClient, TextContentsDetectorClient, TgisClient,
     },
     config::{DetectorType, GenerationProvider, OrchestratorConfig},
@@ -471,17 +471,17 @@ impl StreamingClassificationWithGenTask {
 }
 
 #[derive(Debug)]
-pub struct ChatCompletionTask {
+pub struct ChatCompletionsDetectionTask {
     /// Unique identifier of request trace
     pub trace_id: TraceId,
     /// Chat completion request
-    pub request: ChatCompletionRequest,
+    pub request: ChatCompletionsRequest,
     // Headermap
     pub headers: HeaderMap,
 }
 
-impl ChatCompletionTask {
-    pub fn new(trace_id: TraceId, request: ChatCompletionRequest, headers: HeaderMap) -> Self {
+impl ChatCompletionsDetectionTask {
+    pub fn new(trace_id: TraceId, request: ChatCompletionsRequest, headers: HeaderMap) -> Self {
         Self {
             trace_id,
             request,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -17,6 +17,7 @@
 
 pub mod errors;
 pub use errors::Error;
+pub mod chat_completions;
 pub mod streaming;
 pub mod unary;
 
@@ -35,7 +36,7 @@ use crate::{
             text_context_doc::ContextType, TextChatDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
         },
-        openai::OpenAiClient,
+        openai::{ChatCompletionRequest, OpenAiClient},
         ClientMap, GenerationClient, NlpClient, TextContentsDetectorClient, TgisClient,
     },
     config::{DetectorType, GenerationProvider, OrchestratorConfig},
@@ -464,6 +465,26 @@ impl StreamingClassificationWithGenTask {
             inputs: request.inputs,
             guardrails_config: request.guardrail_config.unwrap_or_default(),
             text_gen_parameters: request.text_gen_parameters,
+            headers,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ChatCompletionTask {
+    /// Unique identifier of request trace
+    pub trace_id: TraceId,
+    /// Chat completion request
+    pub request: ChatCompletionRequest,
+    // Headermap
+    pub headers: HeaderMap,
+}
+
+impl ChatCompletionTask {
+    pub fn new(trace_id: TraceId, request: ChatCompletionRequest, headers: HeaderMap) -> Self {
+        Self {
+            trace_id,
+            request,
             headers,
         }
     }

--- a/src/orchestrator/chat_completions.rs
+++ b/src/orchestrator/chat_completions.rs
@@ -1,0 +1,20 @@
+use tracing::{info, instrument};
+
+use super::{ChatCompletionTask, Error, Orchestrator};
+use crate::clients::openai::{ChatCompletionResponse, OpenAiClient};
+
+impl Orchestrator {
+    #[instrument(skip_all, fields(trace_id = ?task.trace_id, headers = ?task.headers))]
+    pub async fn handle_chat_completions(
+        &self,
+        task: ChatCompletionTask,
+    ) -> Result<ChatCompletionResponse, Error> {
+        info!("handling chat completion task");
+        let client = self
+            .ctx
+            .clients
+            .get_as::<OpenAiClient>("chat_generation")
+            .unwrap();
+        Ok(client.chat_completions(task.request, task.headers).await?)
+    }
+}

--- a/src/orchestrator/chat_completions.rs
+++ b/src/orchestrator/chat_completions.rs
@@ -14,7 +14,7 @@ impl Orchestrator {
             .ctx
             .clients
             .get_as::<OpenAiClient>("chat_generation")
-            .unwrap();
+            .expect("chat_generation client not found");
         Ok(client.chat_completions(task.request, task.headers).await?)
     }
 }

--- a/src/orchestrator/chat_completions_detection.rs
+++ b/src/orchestrator/chat_completions_detection.rs
@@ -1,15 +1,15 @@
 use tracing::{info, instrument};
 
-use super::{ChatCompletionTask, Error, Orchestrator};
-use crate::clients::openai::{ChatCompletionResponse, OpenAiClient};
+use super::{ChatCompletionsDetectionTask, Error, Orchestrator};
+use crate::clients::openai::{ChatCompletionsResponse, OpenAiClient};
 
 impl Orchestrator {
     #[instrument(skip_all, fields(trace_id = ?task.trace_id, headers = ?task.headers))]
-    pub async fn handle_chat_completions(
+    pub async fn handle_chat_completions_detection(
         &self,
-        task: ChatCompletionTask,
-    ) -> Result<ChatCompletionResponse, Error> {
-        info!("handling chat completion task");
+        task: ChatCompletionsDetectionTask,
+    ) -> Result<ChatCompletionsResponse, Error> {
+        info!("handling chat completions detection task");
         let client = self
             .ctx
             .clients


### PR DESCRIPTION
This PR implements the OpenAI Chat Completions Detections API (no detections).

- Conditionally enables the chat completions detection endpoint (`/api/v2/chat/completions-detection`) if chat generation config is provided
- Adds `ChatCompletionsDetectionTask` and `Orchestrator::handle_chat_completions_detection` handler that calls `OpenAiClient::chat_completions()` (handles both unary and streaming)

As `orchestrator/unary.rs` is getting _very_ large, starting with this, I've created a standalone file `orchestrator/chat_completions_detection.rs` for the handler. It also feels weird to add this to "unary" as its both a unary and streaming endpoint. I suggest that we consider opening a PR to split the other handlers into their own files as we have added many new endpoints.

Closes #192 