### PR TITLE
changing unwraps to expect or unwrap_or_else

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -199,8 +199,11 @@ pub async fn create_http_client(default_port: u16, service_config: &ServiceConfi
         Some(_) => "https",
         None => "http",
     };
-    let mut base_url = Url::parse(&format!("{}://{}", protocol, &service_config.hostname)).unwrap();
-    base_url.set_port(Some(port)).unwrap();
+    let mut base_url = Url::parse(&format!("{}://{}", protocol, &service_config.hostname))
+        .unwrap_or_else(|e| panic!("error parsing base url: {}", e));
+    base_url
+        .set_port(Some(port))
+        .unwrap_or_else(|_| panic!("error setting port: {} ", port));
     let request_timeout = Duration::from_secs(
         service_config
             .request_timeout

--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -109,6 +109,7 @@ pub struct ChatDetectionRequest {
     /// Chat messages to run detection on
     pub messages: Vec<Message>,
 
+    /// Detector parameters (available parameters depend on the detector)
     pub detector_params: DetectorParams,
 }
 

--- a/src/clients/detector/text_contents.rs
+++ b/src/clients/detector/text_contents.rs
@@ -24,6 +24,7 @@ use crate::{
     clients::{create_http_client, Client, Error, HttpClient},
     config::ServiceConfig,
     health::HealthCheckResult,
+    models::DetectorParams,
 };
 
 #[cfg_attr(test, faux::create)]
@@ -106,11 +107,17 @@ impl Client for TextContentsDetectorClient {
 pub struct ContentAnalysisRequest {
     /// Field allowing users to provide list of documents for analysis
     pub contents: Vec<String>,
+
+    /// Detector parameters (available parameters depend on the detector)
+    pub detector_params: DetectorParams,
 }
 
 impl ContentAnalysisRequest {
-    pub fn new(contents: Vec<String>) -> ContentAnalysisRequest {
-        ContentAnalysisRequest { contents }
+    pub fn new(contents: Vec<String>, detector_params: DetectorParams) -> ContentAnalysisRequest {
+        ContentAnalysisRequest {
+            contents,
+            detector_params,
+        }
     }
 }
 

--- a/src/clients/detector/text_context_doc.rs
+++ b/src/clients/detector/text_context_doc.rs
@@ -114,7 +114,7 @@ pub struct ContextDocsDetectionRequest {
     /// Context to run detection on
     pub context: Vec<String>,
 
-    // Detector Params
+    /// Detector parameters (available parameters depend on the detector)
     pub detector_params: DetectorParams,
 }
 

--- a/src/clients/detector/text_generation.rs
+++ b/src/clients/detector/text_generation.rs
@@ -24,7 +24,7 @@ use crate::{
     clients::{create_http_client, Client, Error, HttpClient},
     config::ServiceConfig,
     health::HealthCheckResult,
-    models::DetectionResult,
+    models::{DetectionResult, DetectorParams},
 };
 
 #[cfg_attr(test, faux::create)]
@@ -110,13 +110,17 @@ pub struct GenerationDetectionRequest {
 
     /// Text generated from an LLM
     pub generated_text: String,
+
+    /// Detector parameters (available parameters depend on the detector)
+    pub detector_params: DetectorParams,
 }
 
 impl GenerationDetectionRequest {
-    pub fn new(prompt: String, generated_text: String) -> Self {
+    pub fn new(prompt: String, generated_text: String, detector_params: DetectorParams) -> Self {
         Self {
             prompt,
             generated_text,
+            detector_params,
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -31,6 +31,8 @@ use crate::{
     pb,
 };
 
+pub const THRESHOLD_PARAM: &str = "threshold";
+
 #[derive(Clone, Debug, Serialize)]
 pub struct InfoResponse {
     pub services: HealthCheckCache,
@@ -55,7 +57,7 @@ impl DetectorParams {
 
     /// Threshold to filter detector results by score.
     pub fn pop_threshold(&mut self) -> Option<f64> {
-        self.0.remove("threshold").and_then(|v| v.as_f64())
+        self.0.remove(THRESHOLD_PARAM).and_then(|v| v.as_f64())
     }
 }
 

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -270,11 +270,18 @@ async fn streaming_output_detection_task(
         // Create a mutable copy of the parameters, so that we can modify it based on processing
         let mut detector_params = detector_params.clone();
         let detector_id = detector_id.to_string();
-        let chunker_id = ctx.config.get_chunker_id(&detector_id).unwrap();
+        let chunker_id = ctx
+            .config
+            .get_chunker_id(&detector_id)
+            .expect("chunker id is not found");
 
         // Get the detector config
         // TODO: Add error handling
-        let detector_config = ctx.config.detectors.get(&detector_id).unwrap();
+        let detector_config = ctx
+            .config
+            .detectors
+            .get(&detector_id)
+            .expect("detector config not found");
 
         // Get the default threshold to use if threshold is not provided by the user
         let default_threshold = detector_config.default_threshold;
@@ -285,7 +292,7 @@ async fn streaming_output_detection_task(
         // Subscribe to chunk broadcast stream
         let chunk_rx = chunk_broadcast_streams
             .get(&chunker_id)
-            .unwrap()
+            .expect("chunker receiver not found")
             .subscribe();
         let error_tx = error_tx.clone();
         tokio::spawn(detection_task(
@@ -391,7 +398,7 @@ async fn detection_task(
                             let client = ctx
                                 .clients
                                 .get_as::<TextContentsDetectorClient>(&detector_id)
-                                .unwrap();
+                                .expect("text contents detector client not found");
                             match client.text_contents(&detector_id, request, headers)
                                 .await
                                 .map_err(|error| Error::DetectorRequestFailed { id: detector_id.clone(), error }) {

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -291,6 +291,7 @@ async fn streaming_output_detection_task(
         tokio::spawn(detection_task(
             ctx.clone(),
             detector_id.clone(),
+            detector_params,
             threshold,
             detector_tx,
             chunk_rx,
@@ -354,9 +355,11 @@ async fn generation_broadcast_task(
 /// Consumes chunk broadcast stream, sends unary requests to a detector service,
 /// and sends chunk + responses to detection stream.
 #[instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
 async fn detection_task(
     ctx: Arc<Context>,
     detector_id: String,
+    detector_params: DetectorParams,
     threshold: f64,
     detector_tx: mpsc::Sender<(Chunk, Detections)>,
     mut chunk_rx: broadcast::Receiver<Chunk>,
@@ -382,7 +385,7 @@ async fn detection_task(
                             debug!("empty chunk, skipping detector request.");
                             break;
                         } else {
-                            let request = ContentAnalysisRequest::new(contents.clone());
+                            let request = ContentAnalysisRequest::new(contents.clone(), detector_params.clone());
                             let headers = headers.clone();
                             debug!(%detector_id, ?request, "sending detector request");
                             let client = ctx

--- a/src/orchestrator/streaming/aggregator.rs
+++ b/src/orchestrator/streaming/aggregator.rs
@@ -142,7 +142,9 @@ impl ResultActor {
         result.token_classification_results.output = Some(detections);
         if input_start_index == 0 {
             // Get input_token_count and seed from first generation message
-            let first = generations.first().unwrap();
+            let first = generations
+                .first()
+                .expect("first element in classified generated text stream result not found");
             result.input_token_count = first.input_token_count;
             result.seed = first.seed;
             // Get input_tokens from second generation message (if specified)

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -273,13 +273,20 @@ impl Orchestrator {
                         let ctx = ctx.clone();
                         let detector_id = detector_id.clone();
                         let detector_params = detector_params.clone();
-                        let detector_config = ctx.config.detectors.get(&detector_id).unwrap();
+                        let detector_config = ctx
+                            .config
+                            .detectors
+                            .get(&detector_id)
+                            .expect(&format!("detector config not found for {}", detector_id));
 
                         let chunker_id = detector_config.chunker_id.as_str();
 
                         let default_threshold = detector_config.default_threshold;
 
-                        let chunk = chunks.get(chunker_id).unwrap().clone();
+                        let chunk = chunks
+                            .get(chunker_id)
+                            .expect(&format!("chunk not found for {}", chunker_id))
+                            .clone();
 
                         let headers = headers.clone();
 
@@ -752,7 +759,10 @@ pub async fn detect_for_generation(
     let client = ctx
         .clients
         .get_as::<TextGenerationDetectorClient>(&detector_id)
-        .unwrap();
+        .expect(&format!(
+            "error getting text generation detector client {}",
+            detector_id
+        ));
     let response = client
         .text_generation(&detector_id, request, headers)
         .await
@@ -836,7 +846,7 @@ pub async fn detect_for_context(
     let client = ctx
         .clients
         .get_as::<TextContextDocDetectorClient>(&detector_id)
-        .unwrap();
+        .expect("text context doc detector client not found");
     let response = client
         .text_context_doc(&detector_id, request, headers)
         .await

--- a/src/server.rs
+++ b/src/server.rs
@@ -128,15 +128,23 @@ pub async fn run(
         // Configure mTLS if client CA is provided
         let client_auth = if tls_client_ca_cert_path.is_some() {
             info!("Configuring TLS trust certificate (mTLS) for incoming connections");
-            let client_certs = load_certs(tls_client_ca_cert_path.as_ref().unwrap());
+            let client_certs = load_certs(
+                tls_client_ca_cert_path
+                    .as_ref()
+                    .expect("error loading certs for mTLS"),
+            );
             let mut client_auth_certs = RootCertStore::empty();
             for client_cert in client_certs {
                 // Should be only one
-                client_auth_certs.add(client_cert).unwrap();
+                client_auth_certs
+                    .add(client_cert.clone())
+                    .unwrap_or_else(|e| {
+                        panic!("error adding client cert {:?}: {}", client_cert, e)
+                    });
             }
             WebPkiClientVerifier::builder(client_auth_certs.into())
                 .build()
-                .unwrap()
+                .unwrap_or_else(|e| panic!("error building client verifier: {}", e))
         } else {
             WebPkiClientVerifier::no_client_auth()
         };


### PR DESCRIPTION
This PR attempts to start adding error messages for the `unwrap` functions as follows:

- Used `unwrap_or_err` for functions that return results with an err.
- Used expect for functions that return an option.
- Used the convention of `error getting x b/c of y` since it seems thats a pattern of the repo

Since this is a draft I'd like to get feedback on the specificity of error messages. Such as having the error message say `not being to accessing a value from provided key` or just generically `not getting x value`.

Once I know what pattern(s) that need to be implemented I can tackle more but this should spark some conversations.

I also kept with the panics  as a first step and would love to handle the errors more appropriately later on.

Addresses #238 