### PR TITLE
[DRAFT] HTTP and gRPC client middleware for metrics collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "prost",
  "reqwest",
  "reqwest-eventsource",
+ "reqwest-middleware",
  "rustls",
  "rustls-pemfile",
  "rustls-webpki",
@@ -1889,6 +1890,21 @@ dependencies = [
  "pin-project-lite",
  "reqwest",
  "thiserror",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.1.0",
+ "reqwest",
+ "serde",
+ "thiserror",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio", "metrics"] }
 prost = "0.13.1"
 reqwest = { version = "0.12.5", features = ["blocking", "rustls-tls", "json"] }
 reqwest-eventsource = "0.6.0"
+reqwest-middleware = {  version = "0.3.3", features = ["json"] }
 rustls = {version = "0.23.12", default-features = false, features = ["std"]}
 rustls-pemfile = "2.1.3"
 rustls-webpki = "0.102.6"

--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -15,31 +15,30 @@
 
 */
 
-use std::pin::Pin;
-
 use async_trait::async_trait;
 use axum::http::HeaderMap;
-use futures::{Future, Stream, StreamExt, TryStreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use ginepro::LoadBalancedChannel;
-use tonic::{Code, Request, Response, Status, Streaming};
-use tracing::{info, instrument};
+use hyper::StatusCode;
+use tonic::{Request, Response, Status, Streaming};
+use tracing::instrument;
 
 use super::{
-    create_grpc_client, errors::grpc_to_http_code, grpc_request_with_headers, BoxStream, Client,
-    Error,
+    create_grpc_client, grpc::GrpcClient, grpc_request_with_headers, BoxStream, Client, Error,
 };
+use crate::pb::grpc::health::v1::HealthCheckResponse;
 use crate::{
     config::ServiceConfig,
+    grpc_call, grpc_stream_call,
     health::{HealthCheckResult, HealthStatus},
     pb::{
         caikit::runtime::chunkers::{
-            chunkers_service_client::ChunkersServiceClient,
+            chunkers_service_client::ChunkersServiceClient, chunkers_service_server,
             BidiStreamingChunkerTokenizationTaskRequest, ChunkerTokenizationTaskRequest,
         },
         caikit_data_model::nlp::{ChunkerTokenizationStreamResult, Token, TokenizationResults},
-        grpc::health::v1::{health_client::HealthClient, HealthCheckRequest},
+        grpc::health::v1::{health_client::HealthClient, health_server, HealthCheckRequest},
     },
-    tracing_utils::trace_context_from_grpc_response,
 };
 
 const DEFAULT_PORT: u16 = 8085;
@@ -53,15 +52,29 @@ type StreamingTokenizationResult =
 #[cfg_attr(test, faux::create)]
 #[derive(Clone)]
 pub struct ChunkerClient {
-    client: ChunkersServiceClient<LoadBalancedChannel>,
-    health_client: HealthClient<LoadBalancedChannel>,
+    client: GrpcClient<ChunkersServiceClient<LoadBalancedChannel>>,
+    health_client: GrpcClient<HealthClient<LoadBalancedChannel>>,
 }
 
 #[cfg_attr(test, faux::methods)]
 impl ChunkerClient {
     pub async fn new(config: &ServiceConfig) -> Self {
-        let client = create_grpc_client(DEFAULT_PORT, config, ChunkersServiceClient::new).await;
-        let health_client = create_grpc_client(DEFAULT_PORT, config, HealthClient::new).await;
+        let client = create_grpc_client(
+            chunkers_service_server::SERVICE_NAME,
+            DEFAULT_PORT,
+            config,
+            ChunkersServiceClient::new,
+            true,
+        )
+        .await;
+        let health_client = create_grpc_client(
+            health_server::SERVICE_NAME,
+            DEFAULT_PORT,
+            config,
+            HealthClient::new,
+            false,
+        )
+        .await;
         Self {
             client,
             health_client,
@@ -74,12 +87,12 @@ impl ChunkerClient {
         model_id: &str,
         request: ChunkerTokenizationTaskRequest,
     ) -> Result<TokenizationResults, Error> {
-        let mut client = self.client.clone();
         let request = request_with_headers(request, model_id);
-        info!(?request, "sending client request");
-        let response = client.chunker_tokenization_task_predict(request).await?;
-        trace_context_from_grpc_response(&response);
-        Ok(response.into_inner())
+        grpc_call!(
+            self.client,
+            request,
+            ChunkersServiceClient::chunker_tokenization_task_predict
+        )
     }
 
     #[instrument(skip_all, fields(model_id))]
@@ -88,16 +101,20 @@ impl ChunkerClient {
         model_id: &str,
         request_stream: BoxStream<BidiStreamingChunkerTokenizationTaskRequest>,
     ) -> Result<BoxStream<Result<ChunkerTokenizationStreamResult, Error>>, Error> {
-        info!("sending client stream request");
-        let mut client = self.client.clone();
         let request = request_with_headers(request_stream, model_id);
-        // NOTE: this is an ugly workaround to avoid bogus higher-ranked lifetime errors.
-        // https://github.com/rust-lang/rust/issues/110338
-        let response_stream_fut: Pin<Box<dyn Future<Output = StreamingTokenizationResult> + Send>> =
-            Box::pin(client.bidi_streaming_chunker_tokenization_task_predict(request));
-        let response_stream = response_stream_fut.await?;
-        trace_context_from_grpc_response(&response_stream);
-        Ok(response_stream.into_inner().map_err(Into::into).boxed())
+        // let mut client = self.client.inner.clone();
+        // // NOTE: this is an ugly workaround to avoid bogus higher-ranked lifetime errors.
+        // // https://github.com/rust-lang/rust/issues/110338
+        // let response_stream_fut: Pin<Box<dyn Future<Output = StreamingTokenizationResult> + Send>> =
+        //     Box::pin(client.bidi_streaming_chunker_tokenization_task_predict(request));
+        // let response_stream = response_stream_fut.await?;
+        // trace_context_from_grpc_response(&response_stream);
+        // Ok(response_stream.into_inner().map_err(Into::into).boxed())
+        grpc_stream_call!(
+            self.client,
+            request,
+            ChunkersServiceClient::bidi_streaming_chunker_tokenization_task_predict
+        )
     }
 }
 
@@ -108,28 +125,32 @@ impl Client for ChunkerClient {
         "chunker"
     }
 
-    async fn health(&self) -> HealthCheckResult {
-        let mut client = self.health_client.clone();
-        let response = client
-            .check(HealthCheckRequest { service: "".into() })
-            .await;
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
+        let request =
+            grpc_request_with_headers(HealthCheckRequest { service: "".into() }, HeaderMap::new());
+        let response: Result<HealthCheckResponse, Error> =
+            async { grpc_call!(self.health_client, request, HealthClient::check) }.await;
         let code = match response {
-            Ok(_) => Code::Ok,
-            Err(status) if matches!(status.code(), Code::InvalidArgument | Code::NotFound) => {
-                Code::Ok
-            }
-            Err(status) => status.code(),
+            Ok(_) => StatusCode::OK,
+            Err(error) => match error {
+                Error::Grpc {
+                    code: StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND,
+                    ..
+                } => StatusCode::OK,
+                Error::Grpc { code, .. } => code,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
         };
-        let status = if matches!(code, Code::Ok) {
+        let status = if matches!(code, StatusCode::OK) {
             HealthStatus::Healthy
         } else {
             HealthStatus::Unhealthy
         };
-        HealthCheckResult {
+        Ok(HealthCheckResult {
             status,
-            code: grpc_to_http_code(code),
+            code,
             reason: None,
-        }
+        })
     }
 }
 

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -21,7 +21,6 @@ use axum::http::HeaderMap;
 use hyper::StatusCode;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
-use tracing::info;
 use url::Url;
 
 pub mod text_contents;
@@ -63,12 +62,11 @@ pub async fn post_with_headers<T: Debug + Serialize>(
     headers: HeaderMap,
     model_id: &str,
 ) -> Result<Response, Error> {
-    let headers = with_traceparent_header(headers);
-    info!(?url, ?headers, ?request, "sending client request");
+    let mut headers = with_traceparent_header(headers);
+    headers.insert(DETECTOR_ID_HEADER_NAME, model_id.parse().unwrap());
     let response = client
         .post(url)
         .headers(headers)
-        .header(DETECTOR_ID_HEADER_NAME, model_id)
         .json(&request)
         .send()
         .await?;

--- a/src/clients/detector/text_chat.rs
+++ b/src/clients/detector/text_chat.rs
@@ -94,11 +94,11 @@ impl Client for TextChatDetectorClient {
         "text_chat_detector"
     }
 
-    async fn health(&self) -> HealthCheckResult {
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
         if let Some(health_client) = &self.health_client {
-            health_client.health().await
+            Ok(health_client.health().await)
         } else {
-            self.client.health().await
+            Ok(self.client.health().await)
         }
     }
 }

--- a/src/clients/detector/text_contents.rs
+++ b/src/clients/detector/text_contents.rs
@@ -87,11 +87,11 @@ impl Client for TextContentsDetectorClient {
         "text_contents_detector"
     }
 
-    async fn health(&self) -> HealthCheckResult {
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
         if let Some(health_client) = &self.health_client {
-            health_client.health().await
+            Ok(health_client.health().await)
         } else {
-            self.client.health().await
+            Ok(self.client.health().await)
         }
     }
 }

--- a/src/clients/detector/text_context_doc.rs
+++ b/src/clients/detector/text_context_doc.rs
@@ -87,11 +87,11 @@ impl Client for TextContextDocDetectorClient {
         "text_context_doc_detector"
     }
 
-    async fn health(&self) -> HealthCheckResult {
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
         if let Some(health_client) = &self.health_client {
-            health_client.health().await
+            Ok(health_client.health().await)
         } else {
-            self.client.health().await
+            Ok(self.client.health().await)
         }
     }
 }

--- a/src/clients/detector/text_generation.rs
+++ b/src/clients/detector/text_generation.rs
@@ -87,11 +87,11 @@ impl Client for TextGenerationDetectorClient {
         "text_context_doc_detector"
     }
 
-    async fn health(&self) -> HealthCheckResult {
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
         if let Some(health_client) = &self.health_client {
-            health_client.health().await
+            Ok(health_client.health().await)
         } else {
-            self.client.health().await
+            Ok(self.client.health().await)
         }
     }
 }

--- a/src/clients/errors.rs
+++ b/src/clients/errors.rs
@@ -69,6 +69,23 @@ impl From<reqwest::Error> for Error {
     }
 }
 
+impl From<reqwest_middleware::Error> for Error {
+    fn from(value: reqwest_middleware::Error) -> Self {
+        error!(
+            "http request failed. Source: {}",
+            value.source().unwrap().to_string()
+        );
+        let code = match value.status() {
+            Some(code) => code,
+            None => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        Self::Http {
+            code,
+            message: value.to_string(),
+        }
+    }
+}
+
 impl From<tonic::Status> for Error {
     fn from(value: tonic::Status) -> Self {
         Self::Grpc {

--- a/src/clients/generation.rs
+++ b/src/clients/generation.rs
@@ -253,7 +253,7 @@ impl Client for GenerationClient {
         "generation"
     }
 
-    async fn health(&self) -> HealthCheckResult {
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
         match &self.0 {
             Some(GenerationClientInner::Tgis(client)) => client.health().await,
             Some(GenerationClientInner::Nlp(client)) => client.health().await,

--- a/src/clients/grpc.rs
+++ b/src/clients/grpc.rs
@@ -1,0 +1,310 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+use std::future::Future;
+
+#[derive(Clone)]
+pub struct GrpcClient<C> {
+    pub service_name: String,
+    pub inner: C,
+    pub tracing_enabled: bool,
+}
+
+impl<C: Clone> GrpcClient<C> {
+    pub fn new(service_name: String, inner: C, tracing_enabled: bool) -> Self {
+        Self {
+            service_name,
+            inner,
+            tracing_enabled,
+        }
+    }
+}
+
+/// Work around for compiler bug: https://github.com/rust-lang/rust/issues/96865
+pub trait SendFuture: Future {
+    fn send(self) -> impl Future<Output = Self::Output> + Send
+    where
+        Self: Sized + Send,
+    {
+        self
+    }
+}
+
+impl<T: Future> SendFuture for T {}
+
+#[macro_export]
+macro_rules! grpc_call {
+    ($client:expr, $request:expr, $method:expr) => {{
+        use tokio::time::Instant;
+        use tracing::{debug, info};
+
+        use $crate::{tracing_utils::{current_trace_id, trace_context}};
+
+        let mut client = $client.inner.clone();
+
+        // For health clients
+        if !$client.tracing_enabled {
+            let response = $method(&mut client, $request).await?;
+            return Ok(response.into_inner())
+        }
+
+        let trace_id = current_trace_id();
+        let protocol = "gRPC";
+        let service_name = $client.service_name.clone();
+        let request_metadata = $request.metadata();
+
+        info!(?trace_id,
+            protocol,
+            service_name,
+            // method,
+            ?request_metadata,
+            "sending client request"
+        );
+        info!(
+            monotonic_counter.client_request_count = 1,
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            ?request_metadata,
+        );
+        debug!(outgoing_client_request = ?$request);
+
+        let start_time = Instant::now();
+        let client_result = $method(&mut client, $request).await;
+        let request_duration_ms = Instant::now().checked_duration_since(start_time).unwrap().as_millis();
+
+        let (result, response_status, response_metadata) = match client_result {
+            Ok(response) => {
+                let response_status = tonic::Code::Ok;
+                let response_metadata = response.metadata().clone();
+
+                info!(
+                    ?trace_id,
+                    protocol,
+                    service_name,
+                    // method,
+                    request_duration_ms,
+                    ?response_status,
+                    ?response_metadata,
+                    "client response received",
+                );
+                debug!(incoming_client_response = ?response);
+                info!(
+                    monotonic_counter.success_client_response_count = 1,
+                    ?trace_id,
+                    protocol,
+                    service_name,
+                    // method,
+                    request_duration_ms,
+                    ?response_status,
+                    ?response_metadata,
+                );
+
+                (Ok(response.into_inner()), response_status, response_metadata)
+            }
+            Err(error) => {
+                let response_status = error.code();
+                let response_metadata = error.metadata().clone();
+                let error_message = error.message();
+
+                info!(?trace_id, ?response_status, "received client error: {}", error_message);
+
+                info!(
+                    monotonic_counter.client_error_response_count = 1,
+                    ?trace_id,
+                    protocol,
+                    service_name,
+                    // method,
+                    request_duration_ms,
+                    ?response_status,
+                    ?response_metadata,
+                );
+
+                (Err(error), response_status, response_metadata)
+            }
+        };
+
+        info!(
+            monotonic_counter.client_response_count = 1,
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            request_duration_ms,
+            ?response_status,
+            ?response_metadata,
+        );
+        info!(
+            histogram.client_request_duration = request_duration_ms,
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            request_duration_ms,
+            ?response_status,
+            ?response_metadata,
+        );
+
+        trace_context(&response_metadata.clone().into_headers());
+        Ok(result?)
+    }};
+}
+
+#[macro_export]
+macro_rules! grpc_stream_call {
+    ($client:expr, $request:expr, $method:expr) => {{
+        use std::{future::Future, pin::Pin};
+
+        use tokio::time::Instant;
+        use tracing::info;
+
+        use $crate::{
+            clients::grpc::SendFuture,
+            tracing_utils::{current_trace_id, trace_context},
+        };
+
+        let mut client = $client.inner.clone();
+
+        // For health clients
+        if !$client.tracing_enabled {
+            let response = Box::pin($method(&mut client, $request)).send().await?;
+            return Ok(response.into_inner().map_err(Into::into).boxed());
+        }
+
+        let trace_id = current_trace_id();
+        let protocol = "gRPC";
+        let service_name = $client.service_name.clone();
+        let request_metadata = $request.metadata();
+
+        info!(
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            ?request_metadata,
+            "sending client request"
+        );
+        info!(
+            monotonic_counter.client_request_count = 1,
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            ?request_metadata,
+        );
+        // debug!(outgoing_client_request = ?$request);
+
+        let start_time = Instant::now();
+        let client_result: Pin<
+            Box<
+                dyn Future<Output = Result<tonic::Response<tonic::Streaming<_>>, tonic::Status>>
+                    + Send,
+            >,
+        > = Box::pin($method(&mut client, $request));
+        let request_duration_ms = Instant::now()
+            .checked_duration_since(start_time)
+            .unwrap()
+            .as_millis();
+
+        let (result, response_status, response_metadata) = match client_result.await {
+            Ok(response) => {
+                let response_status = tonic::Code::Ok;
+                let response_metadata = response.metadata().clone();
+
+                info!(
+                    ?trace_id,
+                    protocol,
+                    service_name,
+                    // method,
+                    request_duration_ms,
+                    ?response_status,
+                    ?response_metadata,
+                    "client response received",
+                );
+                // debug!(incoming_client_response = ?response);
+                info!(
+                    monotonic_counter.success_client_response_count = 1,
+                    ?trace_id,
+                    protocol,
+                    service_name,
+                    // method,
+                    request_duration_ms,
+                    ?response_status,
+                    ?response_metadata,
+                );
+
+                (
+                    Ok(response.into_inner().map_err(Into::into)),
+                    response_status,
+                    response_metadata,
+                )
+            }
+            Err(error) => {
+                let response_status = error.code();
+                let response_metadata = error.metadata().clone();
+                let error_message = error.message();
+
+                info!(
+                    ?trace_id,
+                    ?response_status,
+                    "received client error: {}",
+                    error_message
+                );
+
+                info!(
+                    monotonic_counter.client_error_response_count = 1,
+                    ?trace_id,
+                    protocol,
+                    service_name,
+                    // method,
+                    request_duration_ms,
+                    ?response_status,
+                    ?response_metadata,
+                );
+
+                (Err(error), response_status, response_metadata)
+            }
+        };
+
+        info!(
+            monotonic_counter.client_response_count = 1,
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            request_duration_ms,
+            ?response_status,
+            ?response_metadata,
+        );
+        info!(
+            histogram.client_request_duration = request_duration_ms,
+            ?trace_id,
+            protocol,
+            service_name,
+            // method,
+            request_duration_ms,
+            ?response_status,
+            ?response_metadata,
+        );
+
+        trace_context(&response_metadata.clone().into_headers());
+        match result {
+            Ok(result) => Ok(result.boxed()),
+            Err(error) => Err(error.into()),
+        }
+    }};
+}

--- a/src/clients/http.rs
+++ b/src/clients/http.rs
@@ -22,15 +22,17 @@ use url::Url;
 
 use crate::health::{HealthCheckResult, HealthStatus, OptionalHealthCheckResponseBody};
 
+pub type ClientImpl = reqwest_middleware::ClientWithMiddleware;
+
 #[derive(Clone)]
 pub struct HttpClient {
     base_url: Url,
     health_url: Url,
-    client: reqwest::Client,
+    client: ClientImpl,
 }
 
 impl HttpClient {
-    pub fn new(base_url: Url, client: reqwest::Client) -> Self {
+    pub fn new(base_url: Url, client: ClientImpl) -> Self {
         let health_url = base_url.join("health").unwrap();
         Self {
             base_url,
@@ -45,7 +47,7 @@ impl HttpClient {
 
     /// This is sectioned off to allow for testing.
     pub(super) async fn http_response_to_health_check_result(
-        res: Result<Response, reqwest::Error>,
+        res: reqwest_middleware::Result<Response>,
     ) -> HealthCheckResult {
         match res {
             Ok(response) => {
@@ -113,7 +115,7 @@ impl HttpClient {
 }
 
 impl std::ops::Deref for HttpClient {
-    type Target = reqwest::Client;
+    type Target = ClientImpl;
 
     fn deref(&self) -> &Self::Target {
         &self.client

--- a/src/clients/openai.rs
+++ b/src/clients/openai.rs
@@ -126,11 +126,11 @@ impl Client for OpenAiClient {
         "openai"
     }
 
-    async fn health(&self) -> HealthCheckResult {
+    async fn health(&self) -> Result<HealthCheckResult, Error> {
         if let Some(health_client) = &self.health_client {
-            health_client.health().await
+            Ok(health_client.health().await)
         } else {
-            self.client.health().await
+            Ok(self.client.health().await)
         }
     }
 }

--- a/src/orchestrator/streaming.rs
+++ b/src/orchestrator/streaming.rs
@@ -161,7 +161,7 @@ impl Orchestrator {
                         let (error_tx, _) = broadcast::channel(1);
 
                         let mut result_rx = match streaming_output_detection_task(
-                            &ctx,
+                            ctx.clone(),
                             detectors,
                             generation_stream,
                             error_tx.clone(),
@@ -224,7 +224,7 @@ impl Orchestrator {
 /// Handles streaming output detection task.
 #[instrument(skip_all)]
 async fn streaming_output_detection_task(
-    ctx: &Arc<Context>,
+    ctx: Arc<Context>,
     detectors: &HashMap<String, DetectorParams>,
     generation_stream: Pin<
         Box<dyn Stream<Item = Result<ClassifiedGeneratedTextStreamResult, Error>> + Send>,
@@ -237,7 +237,7 @@ async fn streaming_output_detection_task(
     // Create generation broadcast stream
     let (generation_tx, generation_rx) = broadcast::channel(1024);
 
-    let chunker_ids = get_chunker_ids(ctx, detectors)?;
+    let chunker_ids = get_chunker_ids(&ctx, detectors)?;
     // Create a map of chunker_id->chunk_broadcast_stream
     // This is to enable fan-out of chunk streams to potentially multiple detectors that use the same chunker.
     // Each detector task will subscribe to an associated chunk stream.

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -128,7 +128,7 @@ impl Orchestrator {
                             .generated_text
                             .clone()
                             .unwrap_or_default();
-                        output_detection_task(&ctx, detectors, generated_text, headers).await?
+                        output_detection_task(ctx, detectors, generated_text, headers).await?
                     }
                     _ => None,
                 };
@@ -524,16 +524,16 @@ pub async fn input_detection_task(
 /// Handles output detection task.
 #[instrument(skip_all)]
 async fn output_detection_task(
-    ctx: &Arc<Context>,
+    ctx: Arc<Context>,
     detectors: &HashMap<String, DetectorParams>,
     generated_text: String,
     headers: HeaderMap,
 ) -> Result<Option<Vec<TokenClassificationResult>>, Error> {
     debug!(detectors = ?detectors.keys(), "starting output detection");
     let text_with_offsets = apply_masks(generated_text, None);
-    let chunker_ids = get_chunker_ids(ctx, detectors)?;
-    let chunks = chunk_task(ctx, chunker_ids, text_with_offsets).await?;
-    let detections = detection_task(ctx, detectors, chunks, headers).await?;
+    let chunker_ids = get_chunker_ids(&ctx, detectors)?;
+    let chunks = chunk_task(&ctx, chunker_ids, text_with_offsets).await?;
+    let detections = detection_task(&ctx, detectors, chunks, headers).await?;
     Ok((!detections.is_empty()).then_some(detections))
 }
 


### PR DESCRIPTION
This PR introduces middleware for both HTTP and gRPC clients allowing metrics to be collected implicitly without overhead in instrumented functions (e.g. client handlers).

Some details still need to be finalized but this should build/function. Leaving in draft until finished revisions but opening for review since this PR introduces significant changes that I think should get looked at sooner rather than later

## Remaining TODO items
- some clean up and code deduplication
- some potential tweaks to allow more "custom" metrics to be collected for given endpoints

## Changes
- introduces HTTP client middleware using `reqwest_middleware` (popular well-maintained thin wrapper for `reqwest` that allows middlewar layers to be added, unfortunately requires modifying usages of `reqwest::Client` to `reqwest_middleware::Client`, but this is essentially just `reqwest::Client` + middleware layers
- there is no good tonic middleware crates. Creating our own middleware solution or maintaining a tonic middleware crate is likely overkill, opted instead to modify grpc clients implementation, adding a `GrpcClient` and `grpc_call!`, `grpc_stream_call!` macros to handle the metrics. The macros were a necessary step up in abstract to forego limitations in Rust's type system regarding Futures and lifetimes
- All handler functions decluttered by these changes