### PR TITLE
Refactor server trace layer middleware

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -57,7 +57,7 @@ use crate::{
         DetectionOnGenerationTask, GenerationWithDetectionTask, Orchestrator,
         StreamingClassificationWithGenTask, TextContentDetectionTask,
     },
-    tracing_utils,
+    tracing_utils::trace_layer,
 };
 
 const API_PREFIX: &str = r#"/api/v1/task"#;
@@ -195,10 +195,11 @@ pub async fn run(
         .with_state(shared_state)
         .layer(
             TraceLayer::new_for_http()
-                .make_span_with(tracing_utils::incoming_request_span)
-                .on_request(tracing_utils::on_incoming_request)
-                .on_response(tracing_utils::on_outgoing_response)
-                .on_eos(tracing_utils::on_outgoing_eos),
+                .make_span_with(trace_layer::server::request_span)
+                .on_request(trace_layer::server::on_request)
+                .on_response(trace_layer::server::on_response)
+                .on_eos(trace_layer::server::on_eos)
+                .on_failure(trace_layer::server::on_failure), // server errors
         );
 
     // (2c) Generate main guardrails server handle based on whether TLS is needed

--- a/src/tracing_utils.rs
+++ b/src/tracing_utils.rs
@@ -15,8 +15,6 @@
 
 */
 
-pub mod trace_layer;
-
 use std::time::Duration;
 
 use hyper::HeaderMap;
@@ -44,6 +42,8 @@ use tracing_opentelemetry::{MetricsLayer, OpenTelemetrySpanExt};
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
 use crate::args::{LogFormat, OtlpProtocol, TracingConfig};
+
+pub mod trace_layer;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TracingError {

--- a/src/tracing_utils/trace_layer.rs
+++ b/src/tracing_utils/trace_layer.rs
@@ -1,0 +1,125 @@
+pub mod server {
+    use crate::tracing_utils::current_trace_id;
+    use axum::extract::Request;
+    use axum::http::HeaderMap;
+    use axum::response::Response;
+    use std::time::Duration;
+    use tower_http::classify::ServerErrorsFailureClass;
+    use tracing::{debug, error, info, info_span, Span};
+
+    pub fn request_span(request: &Request) -> Span {
+        info_span!(
+            "incoming orchestrator request",
+            method = ?request.method(),
+            host = request.uri().host().unwrap_or(""),
+            path = request.uri().path(),
+        )
+    }
+
+    pub fn on_request(request: &Request, span: &Span) {
+        let _guard = span.enter();
+        info!(
+            trace_id = ?current_trace_id(),
+            uri = ?request.uri(),
+            "tracing incoming request",
+        );
+        info!(
+            monotonic_counter.server_request_count = 1,
+            method = ?request.method(),
+            host = request.uri().host().unwrap_or(""),
+            path = request.uri().path(),
+        );
+    }
+
+    pub fn on_response(response: &Response, latency: Duration, span: &Span) {
+        let _guard = span.enter();
+        let trace_id = current_trace_id().to_string();
+        let status_code = response.status().to_string();
+        let latency_ms = latency.as_millis().to_string();
+        info!(trace_id, status_code, latency_ms, "tracing server response");
+        info!(
+            monotonic_counter.server_response_count = 1,
+            status_code, latency_ms,
+        );
+        info!(histogram.server_latency_ms = latency_ms, status_code,);
+
+        if response.status().is_server_error() {
+            // On every server error (HTTP 5xx) response
+            // This should be caught by on_failure given the right classifier is used
+            info!(
+                monotonic_counter.server_5xx_error_response_count = 1,
+                status_code, latency_ms,
+            );
+        } else if response.status().is_client_error() {
+            // On every client error (HTTP 4xx) response
+            info!(
+                monotonic_counter.server_4xx_error_response_count = 1,
+                status_code, latency_ms,
+            );
+        } else if response.status().is_success() {
+            // On every successful (HTTP 2xx) response
+            info!(
+                monotonic_counter.server_success_response_count = 1,
+                status_code, latency_ms,
+            );
+        }
+    }
+
+    pub fn on_eos(trailers: Option<&HeaderMap>, stream_duration: Duration, span: &Span) {
+        let _guard = span.enter();
+        let trace_id = current_trace_id().to_string();
+        let stream_duration_ms = stream_duration.as_millis().to_string();
+
+        info!(trace_id, stream_duration_ms, "server end of stream");
+        debug!(?trailers, "server end of stream trailer headers");
+        info!(
+            monotonic_counter.server_stream_response_count = 1,
+            stream_duration_ms,
+        );
+        info!(histogram.server_stream_duration_ms = stream_duration_ms);
+    }
+
+    pub fn on_failure(
+        failure_classification: ServerErrorsFailureClass,
+        latency: Duration,
+        span: &Span,
+    ) {
+        let _guard = span.enter();
+        let trace_id = current_trace_id().to_string();
+        let latency_ms = latency.as_millis().to_string();
+
+        let (status_code, error) = match failure_classification {
+            ServerErrorsFailureClass::StatusCode(status_code) => {
+                error!(
+                    trace_id,
+                    ?status_code,
+                    latency_ms,
+                    "server failed to handle request",
+                );
+                (Some(status_code), None)
+            }
+            ServerErrorsFailureClass::Error(error) => {
+                error!(
+                    trace_id,
+                    latency_ms, "server failed to handle request - {}", error,
+                );
+                (None, Some(error))
+            }
+        };
+
+        info!(
+            monotonic_counter.server_request_failure_count = 1,
+            latency_ms,
+            ?status_code,
+            ?error
+        );
+        info!(
+            monotonic_counter.server_5xx_response_count = 1,
+            latency_ms,
+            ?status_code,
+            ?error
+        );
+    }
+}
+
+pub mod client {}

--- a/src/tracing_utils/trace_layer.rs
+++ b/src/tracing_utils/trace_layer.rs
@@ -1,11 +1,11 @@
 pub mod server {
-    use crate::tracing_utils::current_trace_id;
-    use axum::extract::Request;
-    use axum::http::HeaderMap;
-    use axum::response::Response;
     use std::time::Duration;
+
+    use axum::{extract::Request, http::HeaderMap, response::Response};
     use tower_http::classify::ServerErrorsFailureClass;
     use tracing::{debug, error, info, info_span, Span};
+
+    use crate::tracing_utils::current_trace_id;
 
     pub fn request_span(request: &Request) -> Span {
         info_span!(


### PR DESCRIPTION
In recent discussions regarding client metrics collection middleware-based implementation @declark1 recommended making use of `tower::Service`. This is the same approach that the server already uses for its own tracing middleware. The purpose of this PR is to factor out the tracelayer functions to a separate mod as a prerequisite to the PR that will introduce similar infra for clients. This PR introduces a trace_layer submodule to house the different trace layer functions for server and client

Note: This PR is separate from the upcoming client middleware PR in order to keep work items separated for this collection of changes. However, I think I still may end up making modifications to this PR as I finish refining the client middleware PR, so just an FYI there may be tweaks here based on the details of that implementation