### PR TITLE
Expose modules and types publicly for integration tests, add ServiceConfig::new

### DIFF
--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -43,7 +43,7 @@ use crate::{
 };
 
 const DEFAULT_PORT: u16 = 8085;
-const MODEL_ID_HEADER_NAME: &str = "mm-model-id";
+pub const MODEL_ID_HEADER_NAME: &str = "mm-model-id";
 /// Default chunker that returns span for entire text
 pub const DEFAULT_CHUNKER_ID: &str = "whole_doc_chunker";
 

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -38,7 +38,7 @@ pub mod text_generation;
 pub use text_generation::*;
 
 const DEFAULT_PORT: u16 = 8080;
-const DETECTOR_ID_HEADER_NAME: &str = "detector-id";
+pub const DETECTOR_ID_HEADER_NAME: &str = "detector-id";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DetectorError {

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,17 @@ pub struct ServiceConfig {
     pub tls: Option<Tls>,
 }
 
+impl ServiceConfig {
+    pub fn new(hostname: String, port: u16) -> Self {
+        Self {
+            hostname,
+            port: Some(port),
+            request_timeout: None,
+            tls: None,
+        }
+    }
+}
+
 /// TLS provider
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,12 @@
 #![allow(clippy::iter_kv_map, clippy::enum_variant_names, async_fn_in_trait)]
 
 pub mod args;
-mod clients;
+pub mod clients;
 pub mod config;
 pub mod health;
-mod models;
+pub mod models;
 pub mod orchestrator;
-mod pb;
+pub mod pb;
 pub mod server;
 pub mod utils;
 #[allow(unused_imports)]


### PR DESCRIPTION
Small PR to expose modules and types publicly for integration tests. Also adds `ServiceConfig::new` method for convenience.

Closes #265 