### PR TITLE
Bug fix - added json header to detector client response

### DIFF
--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -87,6 +87,8 @@ impl<C: DetectorClient + HttpClientExt> DetectorClientExt for C {
     ) -> Result<U, Error> {
         let mut headers = headers;
         headers.append(DETECTOR_ID_HEADER_NAME, model_id.parse().unwrap());
+        headers.append("content-type", "application/json".parse().unwrap());
+
         let response = self.inner().post(url, headers, request).await?;
 
         let status = response.status();


### PR DESCRIPTION
While communicating with my local detector service, I encountered a 415 error, which seemed to have appeared after commit a4964b119893025eaf8056268b5cd8c4af29ad6d. Prior to this commit, the error was not present.

After discussing the issue with @evaline-ju, we discovered that explicitly sending text-contents/json headers to the detector client seemed to resolve the issue. We suspect that this problem may have stemmed from the switch from the reqwest library to hyper.