### PR TITLE
:wrench: Add header on detector requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,9 +2987,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ tracing = "0.1.41"
 tracing-opentelemetry = "0.28.0"
 tracing-subscriber = { version = "0.3.19", features = ["json", "env-filter"] }
 url = "2.5.4"
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.12.1", features = ["v4"] }
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -18,6 +18,7 @@
 use std::fmt::Debug;
 
 use axum::http::HeaderMap;
+use http::header::CONTENT_TYPE;
 use hyper::StatusCode;
 use serde::Deserialize;
 use tracing::instrument;
@@ -39,7 +40,6 @@ pub use text_generation::*;
 
 const DEFAULT_PORT: u16 = 8080;
 pub const DETECTOR_ID_HEADER_NAME: &str = "detector-id";
-const CONTENT_TYPE_HEADER_NAME: &str = "content-type";
 const MODEL_HEADER_NAME: &str = "x-model-name";
 
 #[derive(Debug, Clone, Deserialize)]
@@ -89,10 +89,7 @@ impl<C: DetectorClient + HttpClientExt> DetectorClientExt for C {
     ) -> Result<U, Error> {
         let mut headers = headers;
         headers.append(DETECTOR_ID_HEADER_NAME, model_id.parse().unwrap());
-        headers.append(
-            CONTENT_TYPE_HEADER_NAME,
-            "application/json".parse().unwrap(),
-        );
+        headers.append(CONTENT_TYPE, "application/json".parse().unwrap());
         // Header used by a router component, if available
         headers.append(MODEL_HEADER_NAME, model_id.parse().unwrap());
 

--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -39,6 +39,8 @@ pub use text_generation::*;
 
 const DEFAULT_PORT: u16 = 8080;
 pub const DETECTOR_ID_HEADER_NAME: &str = "detector-id";
+const CONTENT_TYPE_HEADER_NAME: &str = "content-type";
+const MODEL_HEADER_NAME: &str = "x-model-name";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DetectorError {
@@ -87,7 +89,12 @@ impl<C: DetectorClient + HttpClientExt> DetectorClientExt for C {
     ) -> Result<U, Error> {
         let mut headers = headers;
         headers.append(DETECTOR_ID_HEADER_NAME, model_id.parse().unwrap());
-        headers.append("content-type", "application/json".parse().unwrap());
+        headers.append(
+            CONTENT_TYPE_HEADER_NAME,
+            "application/json".parse().unwrap(),
+        );
+        // Header used by a router component, if available
+        headers.append(MODEL_HEADER_NAME, model_id.parse().unwrap());
 
         let response = self.inner().post(url, headers, request).await?;
 


### PR DESCRIPTION
- Upgrade UUID [was originally removed as unused in #281 but was not upgraded after being added back]
- Add a new `x-model-name` header to be a used by an optional router component, if available. The decision was made to always just add this header, as opposed to adding more configuration or conditional logic.

Debug log example [some details obscured] - full requests are not on info level
```
2025-01-22T20:33:04.638671Z DEBUG incoming_orchestrator_http_request{request_method="POST" request_path="/api/v1/task/server-streaming-classification-with-text-generation" response_status_code=200 request_duration_ms=2}:stream_classification_with_gen{model_id="my-llm"}:handle_streaming_classification_with_gen{trace_id="f466fbf7eb4c46ea987530d5fbb624f9" model_id="my-llm" headers={}}:streaming_output_detection_task:detection_task:text_contents:post_to_detector:post:send: fms_guardrails_orchestr8::clients::http: sending client request url=Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("my-domain")), port: None, path: "/api/v1/text/contents", query: None, fragment: None } headers={"detector-id": "my-detector", "content-type": "application/json", "x-model-name": "my-detector", "traceparent": "00-f466fbf7eb4c46ea987530d5fbb624f9-78d9cd28c93d332d-01", "tracestate": ""} body=ContentAnalysisRequest { contents: ["\nMatthew: Making 3.5 a mile"], detector_params: DetectorParams({}) }
```