### PR TITLE
Add error handling for unknown fields in orchestrator request

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -77,6 +77,7 @@ impl std::ops::DerefMut for DetectorParams {
 
 /// User request to orchestrator
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GuardrailsHttpRequest {
     /// Text generation model ID
     pub model_id: String,
@@ -343,6 +344,7 @@ pub struct ClassifiedGeneratedTextResult {
 
 /// The request format expected in the /api/v2/text/detection/content endpoint.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TextContentDetectionHttpRequest {
     /// The content to run detectors on
     pub content: String,
@@ -836,6 +838,7 @@ impl From<pb::caikit_data_model::nlp::GeneratedTextResult> for ClassifiedGenerat
 
 /// The request format expected in the /api/v2/text/generation-detection endpoint.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GenerationWithDetectionHttpRequest {
     /// The model_id of the LLM to be invoked.
     pub model_id: String,
@@ -917,6 +920,7 @@ pub enum GuardrailDetection {
 
 /// The request format expected in the /api/v2/text/context endpoint.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContextDocsHttpRequest {
     /// The map of detectors to be used, along with their respective parameters, e.g. thresholds.
     pub detectors: HashMap<String, DetectorParams>,
@@ -958,8 +962,9 @@ pub struct ContextDocsResult {
     pub detections: Vec<DetectionResult>,
 }
 
-/// The request format expected in the /api/v2/text/detect/generated endpoint.
+/// The request format expected in the /api/v2/text/detect/chat endpoint.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ChatDetectionHttpRequest {
     /// The map of detectors to be used, along with their respective parameters, e.g. thresholds.
     pub detectors: HashMap<String, DetectorParams>,
@@ -1033,6 +1038,7 @@ pub struct ChatDetectionResult {
 
 /// The request format expected in the /api/v2/text/detect/generated endpoint.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DetectionOnGeneratedHttpRequest {
     /// The prompt to be sent to the LLM.
     pub prompt: String,
@@ -1120,6 +1126,7 @@ pub struct EvidenceObj {
 
 /// Stream content detection stream request
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Default))]
 pub struct StreamingContentDetectionRequest {
     pub detectors: Option<HashMap<String, DetectorParams>>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1213,6 +1213,32 @@ mod tests {
         let error = result.unwrap_err().to_string();
         assert!(error.contains("`model_id` is required"));
 
+        // Additional unknown field (guardrails_config, a typo of the accurate "guardrail_config")
+        let json_data = r#"
+        {
+            "inputs": "The cow jumped over the moon.",
+            "model_id": "model-id",
+            "guardrails_config": {
+                "input": {
+                    "models": {
+                        "hap_model": {}
+                    }
+                },
+                "output": {
+                    "models": {
+                        "hap_model": {}
+                    }
+                }
+            }
+        }
+        "#;
+        let result: Result<GuardrailsHttpRequest, _> = serde_json::from_str(json_data);
+        assert!(result.is_err());
+        let error = result.unwrap_err().to_string();
+        assert!(error
+            .to_string()
+            .contains("unknown field `guardrails_config`"));
+
         // No inputs
         let request = GuardrailsHttpRequest {
             model_id: "model".to_string(),

--- a/src/orchestrator/chat_completions_detection.rs
+++ b/src/orchestrator/chat_completions_detection.rs
@@ -14,20 +14,25 @@
  limitations under the License.
 
 */
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
 use axum::http::HeaderMap;
 use futures::future::{join_all, try_join_all};
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::{collections::HashMap, sync::Arc};
+use serde::{Deserialize, Serialize};
 use tracing::{debug, info, instrument};
+use uuid::Uuid;
 
 use super::{ChatCompletionsDetectionTask, Context, Error, Orchestrator};
-use crate::clients::openai::OrchestratorWarning;
 use crate::{
     clients::{
         detector::{ChatDetectionRequest, ContentAnalysisRequest},
         openai::{
             ChatCompletion, ChatCompletionChoice, ChatCompletionsRequest, ChatCompletionsResponse,
-            ChatDetections, Content, InputDetectionResult, OpenAiClient,
+            ChatDetections, Content, InputDetectionResult, OpenAiClient, OrchestratorWarning,
         },
     },
     config::DetectorType,
@@ -38,8 +43,6 @@ use crate::{
         Chunk, UNSUITABLE_INPUT_MESSAGE,
     },
 };
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 /// Internal structure to capture chat messages (both request and response)
 /// and prepare it for processing
@@ -386,8 +389,10 @@ mod tests {
     use std::any::{Any, TypeId};
 
     use super::*;
-    use crate::config::DetectorConfig;
-    use crate::orchestrator::{ClientMap, OrchestratorConfig};
+    use crate::{
+        config::DetectorConfig,
+        orchestrator::{ClientMap, OrchestratorConfig},
+    };
 
     // Test to verify preprocess_chat_messages works correctly for multiple content type detectors
     // with single message in chat request

--- a/src/orchestrator/detector_processing/content.rs
+++ b/src/orchestrator/detector_processing/content.rs
@@ -55,7 +55,6 @@ pub fn filter_chat_messages(
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::orchestrator::chat_completions_detection::ChatMessageInternal;
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -489,7 +489,10 @@ async fn stream_content_detection(
 async fn detection_content(
     State(state): State<Arc<ServerState>>,
     headers: HeaderMap,
-    Json(request): Json<models::TextContentDetectionHttpRequest>,
+    WithRejection(Json(request), _): WithRejection<
+        Json<models::TextContentDetectionHttpRequest>,
+        Error,
+    >,
 ) -> Result<impl IntoResponse, Error> {
     let trace_id = Span::current().context().span().span_context().trace_id();
     info!(?trace_id, "handling request");


### PR DESCRIPTION
**Story:**  [foundation-model-stack/fms-guardrails-orchestrator#261](https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/261)

## What does your PR do?
This PR adds a container attribute from the serde framework to handle unknown fields passed into to a request for ochestrator APIs. A unit test is also added asserting the case used for the scenario used in the git issue.  

### How this was tested 
In addition to the unit test, each endpoint was modified to have a field name with a typo, or an outright made up field, and compared with an older orchestrator version deployed on openshift, versus the locally modified version. 

Example:
```
curl --request POST   --url 'http://localhost:8033/api/v1/task/server-streaming-classification-with-text-generation'  --header 'Content-Type: application/json'  --data '{"inputs": "All people from Kish are cruel and evil.","model_id": "bloom-560m","guardrails_config": {"input": {"models": {"en_syntax_slate.38m.hap": {}}},"output": {"models": {"en_syntax_slate.38m.hap": {}}}},"text_gen_parameters": {"preserve_input_text": true,"max_new_tokens": 99,"min_new_tokens": 1,"truncate_input_tokens": 500,"decoding_method": "SAMPLING","top_k": 2,"top_p": 0.9,"typical_p": 0.5,"temperature": 0.8,"seed": 42,"repetition_penalty": 2,"max_time": 0,"stop_sequences": ["42"]}}'
{"code":422,"details":"guardrails_config: unknown field `guardrails_config`, expected one of `model_id`, `inputs`, `guardrail_config`, `text_gen_parameters` at line 1 column 98"}
```