### PR TITLE
Revert ":wrench: Assume http2 for grpc clients (#284)"

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -290,10 +290,8 @@ pub async fn create_grpc_client<C: Debug + Clone>(
             .await
             .unwrap_or_else(|error| panic!("error reading key from {key_path:?}: {error}"));
         let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
-        // assume_http2 added ref. https://github.com/hyperium/tonic/issues/1427
         let mut client_tls_config = tonic::transport::ClientTlsConfig::new()
             .identity(identity)
-            .assume_http2(true)
             .with_native_roots()
             .with_webpki_roots();
         if let Some(client_ca_cert_path) = &tls_config.client_ca_cert_path {


### PR DESCRIPTION
This reverts commit 972021755298270099de4bc933aa06a3c2133052.

Has not seemed to resolve TLS issues