### PR TITLE
Add error handling for unknown fields for chat completion detection request

### DIFF
--- a/src/clients/openai.rs
+++ b/src/clients/openai.rs
@@ -172,6 +172,7 @@ impl From<ChatCompletion> for ChatCompletionsResponse {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ChatCompletionsRequest {
     /// A list of messages comprising the conversation so far.
     pub messages: Vec<Message>,
@@ -290,6 +291,7 @@ pub struct ChatCompletionsRequest {
 
 /// Structure to contain parameters for detectors.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DetectorConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input: Option<HashMap<String, DetectorParams>>,
@@ -398,6 +400,7 @@ pub enum Role {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Message {
     /// The role of the author of this message.
     pub role: Role,


### PR DESCRIPTION
## What does your PR do?
This PR adds a container attribute from the serde framework to handle unknown fields passed into to a request for the chat completion detection (including the message and the detection section). A unit test is also added asserting the case used for the scenario used in the git issue.  

### How this was tested 
The endpoint was modified to have an additional field in parts of the request, and compare with an current orchestrator version deployed on openshift, versus the locally updated version. 

Example:
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/chat/completions-detection' \
>   -H 'accept: application/json' \
>   -H 'Content-Type: application/json' \
>   -d '{
>   "messages": [
>     {
>       "content": "this is a nice sentence",
>       "role": "user",
>       "name": "string",
>       "additional": "test"
>     }
>   ],
>   "model": "/llama_3_storage/hf/8b_instruction_tuned",
>   "n": 1,
>   "temperature": 1,
>   "top_p": 1,
>   "user": "user-1234",
>   "detectors": {
>     "input": {
>       "en_syntax_slate.38m.hap": {},
>       "en_syntax_rbr_pii": {}
>     }
>   }
> }'
{"code":422,"details":"messages[0].additional: unknown field `additional`, expected one of `role`, `content`, `name`, `refusal`, `tool_calls`, `tool_call_id` at line 7 column 18"}
```

```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/chat/completions-detection' \
>   -H 'accept: application/json' \
>   -H 'Content-Type: application/json' \
>   -d '{
>   "messages": [
>     {
>       "content": "this is a nice sentence",
>       "role": "user",
>       "name": "string"
>     }
>   ],
>   "model": "/llama_3_storage/hf/8b_instruction_tuned",
>   "additional_field": "test",
>   "n": 1,
>   "temperature": 1,
>   "top_p": 1,
>   "user": "user-1234",
>   "detectors": {
>     "input": {
>       "en_syntax_slate.38m.hap": {},
>       "en_syntax_rbr_pii": {}
>     }
>   }
> }'
{"code":422,"details":"additional_field: unknown field `additional_field`, expected one of `messages`, `model`, `store`, `metadata`, `frequency_penalty`, `logit_bias`, `logprobs`, `top_logprobs`, `max_tokens`, `max_completion_tokens`, `n`, `presence_penalty`, `response_format`, `seed`, `service_tier`, `stop`, `stream`, `stream_options`, `temperature`, `top_p`, `tools`, `tool_choice`, `parallel_tool_calls`, `user`, `best_of`, `use_beam_search`, `top_k`, `min_p`, `repetition_penalty`, `length_penalty`, `early_stopping`, `ignore_eos`, `min_tokens`, `stop_token_ids`, `skip_special_tokens`, `spaces_between_special_tokens`, `detectors` at line 10 column 20"}
```

```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/chat/completions-detection' \
>   -H 'accept: application/json' \
>   -H 'Content-Type: application/json' \
>   -d '{
>   "messages": [
>     {
>       "content": "this is a nice sentence",
>       "role": "user",
>       "name": "string"
>     }
>   ],
>   "model": "/llama_3_storage/hf/8b_instruction_tuned",
>   "n": 1,
>   "temperature": 1,
>   "top_p": 1,
>   "user": "user-1234",
>   "detectors": {
>     "input": {
>       "en_syntax_slate.38m.hap": {},
>       "en_syntax_rbr_pii": {}
>     },
>    "additional_detector_field": "test"
>   }
> }'
{"code":422,"details":"detectors.additional_detector_field: unknown field `additional_detector_field`, expected `input` or `output` at line 19 column 30"}
```