### PR TITLE
removed most of the warnings from Dockerfile when running docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG CONFIG_FILE=config/config.yaml
 
 ## Rust builder ################################################################
 # Specific debian version so that compatible glibc version is used
-FROM rust:1.84.0-bullseye as rust-builder
+FROM rust:1.84.0-bullseye AS rust-builder
 ARG PROTOC_VERSION
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
@@ -22,7 +22,7 @@ COPY rust-toolchain.toml rust-toolchain.toml
 RUN rustup component add rustfmt
 
 ## Orchestrator builder #########################################################
-FROM rust-builder as fms-guardrails-orchestr8-builder
+FROM rust-builder AS fms-guardrails-orchestr8-builder
 
 COPY build.rs *.toml LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
@@ -35,20 +35,20 @@ WORKDIR /app
 RUN cargo install --root /app/ --path .
 
 ## Tests stage ##################################################################
-FROM fms-guardrails-orchestr8-builder as tests
+FROM fms-guardrails-orchestr8-builder AS tests
 RUN cargo test
 
 ## Lint stage ###################################################################
-FROM fms-guardrails-orchestr8-builder as lint
+FROM fms-guardrails-orchestr8-builder AS lint
 RUN cargo clippy --all-targets --all-features -- -D warnings
 
 ## Formatting check stage #######################################################
-FROM fms-guardrails-orchestr8-builder as format
+FROM fms-guardrails-orchestr8-builder AS format
 RUN cargo fmt --check
 
 ## Release Image ################################################################
 
-FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} as fms-guardrails-orchestr8-release
+FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS fms-guardrails-orchestr8-release
 
 COPY --from=fms-guardrails-orchestr8-builder /app/bin/ /app/bin/
 COPY ${CONFIG_FILE} /app/config/config.yaml
@@ -63,6 +63,6 @@ RUN groupadd --system orchestr8 --gid 1001 && \
 
 USER orchestr8
 
-ENV ORCHESTRATOR_CONFIG /app/config/config.yaml
+ENV ORCHESTRATOR_CONFIG=/app/config/config.yaml
 
-CMD /app/bin/fms-guardrails-orchestr8
+CMD ["/app/bin/fms-guardrails-orchestr8"]


### PR DESCRIPTION
This PR removes most of the warnings when building the container image using `docker build`.

Previous Warnings:
```
 10 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 8)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 25)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 38)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 42)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 46)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 51)
 - UndefinedVar: Usage of undefined variable '$CONFIG_FILE' (line 28)
 - UndefinedVar: Usage of undefined variable '$CONFIG_FILE' (line 54)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 66)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 68)
```

Currently:
```
 2 warnings found (use --debug to expand):
 - UndefinedVar: Usage of undefined variable '$CONFIG_FILE' (line 28)
 - UndefinedVar: Usage of undefined variable '$CONFIG_FILE' (line 54)

```