### PR TITLE
:wrench: Make grpc dns probe interval configurable per client

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -69,6 +69,7 @@ pub mod openai;
 
 const DEFAULT_CONNECT_TIMEOUT_SEC: u64 = 60;
 const DEFAULT_REQUEST_TIMEOUT_SEC: u64 = 600;
+const DEFAULT_GRPC_PROBE_INTERVAL_SEC: u64 = 10;
 
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 
@@ -270,13 +271,19 @@ pub async fn create_grpc_client<C: Debug + Clone>(
     let mut base_url = Url::parse(&format!("{}://{}", protocol, &service_config.hostname)).unwrap();
     base_url.set_port(Some(port)).unwrap();
     debug!(%base_url, "creating gRPC client");
-    let connect_timeout = Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SEC);
+    let connect_timeout = Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SEC);
     let request_timeout = Duration::from_secs(
         service_config
             .request_timeout
             .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SEC),
     );
+    let grpc_dns_probe_interval_sec = Duration::from_secs(
+        service_config
+            .grpc_dns_probe_interval_secs
+            .unwrap_or(DEFAULT_GRPC_PROBE_INTERVAL_SEC),
+    );
     let mut builder = LoadBalancedChannel::builder((service_config.hostname.clone(), port))
+        .dns_probe_interval(grpc_dns_probe_interval_sec)
         .connect_timeout(connect_timeout)
         .timeout(request_timeout);
 

--- a/src/clients.rs
+++ b/src/clients.rs
@@ -277,13 +277,13 @@ pub async fn create_grpc_client<C: Debug + Clone>(
             .request_timeout
             .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SEC),
     );
-    let grpc_dns_probe_interval_sec = Duration::from_secs(
+    let grpc_dns_probe_interval = Duration::from_secs(
         service_config
-            .grpc_dns_probe_interval_secs
+            .grpc_dns_probe_interval
             .unwrap_or(DEFAULT_GRPC_PROBE_INTERVAL_SEC),
     );
     let mut builder = LoadBalancedChannel::builder((service_config.hostname.clone(), port))
-        .dns_probe_interval(grpc_dns_probe_interval_sec)
+        .dns_probe_interval(grpc_dns_probe_interval)
         .connect_timeout(connect_timeout)
         .timeout(request_timeout);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,8 @@ pub struct ServiceConfig {
     pub request_timeout: Option<u64>,
     /// TLS provider info
     pub tls: Option<Tls>,
+    /// gRPC probe interval in seconds
+    pub grpc_dns_probe_interval_secs: Option<u64>,
 }
 
 impl ServiceConfig {
@@ -74,6 +76,7 @@ impl ServiceConfig {
             port: Some(port),
             request_timeout: None,
             tls: None,
+            grpc_dns_probe_interval_secs: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,7 +66,7 @@ pub struct ServiceConfig {
     /// TLS provider info
     pub tls: Option<Tls>,
     /// gRPC probe interval in seconds
-    pub grpc_dns_probe_interval_secs: Option<u64>,
+    pub grpc_dns_probe_interval: Option<u64>,
 }
 
 impl ServiceConfig {
@@ -76,7 +76,7 @@ impl ServiceConfig {
             port: Some(port),
             request_timeout: None,
             tls: None,
-            grpc_dns_probe_interval_secs: None,
+            grpc_dns_probe_interval: None,
         }
     }
 }


### PR DESCRIPTION
### Changes

- Make grpc probe configurable per client
- Fix default connect timeout