### PR TITLE
pre-refactor: Add orchestrator.types module with common types

### DIFF
--- a/docs/architecture/adrs/010-detection-batcher.md
+++ b/docs/architecture/adrs/010-detection-batcher.md
@@ -27,7 +27,7 @@ To support initial streaming requirements outlined in ADR 002, we implemented th
 
 The primary issue with these components is that they were designed specifically for the *Streaming Classification With Generation* task and lack flexibility to be extended to additional streaming use cases that require batching detections, e.g.
 - A use case may require different batching logic
-- A use case may need to use different containers to implement it's batching logic
+- A use case may need to use different data structures to implement it's batching logic
 - A use case may need to return a different batch type
 - A use case may need to build a different result type
 

--- a/docs/architecture/adrs/010-detection-batcher.md
+++ b/docs/architecture/adrs/010-detection-batcher.md
@@ -1,0 +1,49 @@
+# ADR 010: DetectionBatcher & DetectionBatchStream
+
+This ADR documents the addition of two new abstractions to handle batching (fka "aggregation") of streaming detection results. 
+
+1. `DetectionBatcher`
+A trait to implement pluggable batching logic for a `DetectionBatchStream`. It includes an associated `Batch` type, enabling implementations to return different types of batches.
+
+2. `DetectionBatchStream`
+A stream adapter that wraps multiple detection streams and produces a stream of batches using a `DetectionBatcher`.
+
+## Motivation
+
+To support initial streaming requirements outlined in ADR 002, we implemented the `Aggregator` and `Tracker` components.
+
+1. `Aggregator` handles batching detections and building results. Internally, it is implemented as 3 actors:
+
+    - `AggregationActor`
+    Aggregates detections and sends them to the `ResultActor`
+
+    - `GenerationActor`
+    Consumes generations from the generation stream, accumulates them, and provides them on-demand to the `ResultActor` to build responses
+
+    - `ResultActor`
+    Builds results from detection batches and generations and sends them to result channel
+
+2. `Tracker` wraps a BTreeMap and contains batching logic. It is used internally by the `AggregationActor`.
+
+The primary issue with these components is that they were designed specifically for the *Streaming Classification With Generation* task and lack flexibility to be extended to additional streaming use cases that require batching detections, e.g.
+- A use case may require different batching logic
+- A use case may need to use different containers to implement it's batching logic
+- A use case may need to return a different batch type
+- A use case may need to build a different result type
+
+Additionally, actors are not used in other areas of this codebase and it introduces concepts that may be unfamiliar to new contributors, further increasing the learning curve.
+
+## Decisions
+
+1. The `DetectionBatcher` trait replaces the `Tracker`, enabling flexible and pluggable batching logic tailored to different use cases.
+
+2. The `DetectionBatchStream`, a stream adapter, replaces the `Aggregator`, enabling more flexiblity as it is generic over `DetectionBatcher`.
+
+3. The task of building results is decoupled and delegated to the task handler as a post-batching task. Instead of using an actor to accumulate and own generation/chat completion message state, a task handler can use a shared vec instead, e.g. `Arc<RwLock<Vec<T>>>`, or other approach per use case requirements.
+
+## Notes
+1. The existing *Streaming Classification With Generation* batching logic has been re-implemented in `MaxProcessedIndexBatcher`, a `DetectionBatcher` implementation.
+
+## Status
+
+Pending

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -23,6 +23,7 @@ pub mod common;
 pub mod detector_processing;
 pub mod streaming;
 pub mod streaming_content_detection;
+pub mod types;
 pub mod unary;
 
 use std::{collections::HashMap, pin::Pin, sync::Arc};

--- a/src/orchestrator/common.rs
+++ b/src/orchestrator/common.rs
@@ -1,2 +1,18 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 pub mod utils;
 pub use utils::*;

--- a/src/orchestrator/common/utils.rs
+++ b/src/orchestrator/common/utils.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{

--- a/src/orchestrator/types.rs
+++ b/src/orchestrator/types.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use std::pin::Pin;
 
 use futures::Stream;

--- a/src/orchestrator/types.rs
+++ b/src/orchestrator/types.rs
@@ -1,0 +1,31 @@
+use std::pin::Pin;
+
+use futures::Stream;
+use tokio::sync::mpsc;
+
+pub mod chat_message;
+pub use chat_message::*;
+pub mod chunk;
+pub mod detection;
+pub use chunk::*;
+pub use detection::*;
+pub mod detection_batcher;
+pub use detection_batcher::*;
+pub mod detection_batch_stream;
+pub use detection_batch_stream::*;
+
+use super::Error;
+use crate::{clients::openai::ChatCompletionChunk, models::ClassifiedGeneratedTextStreamResult};
+
+pub type ChunkerId = String;
+pub type DetectorId = String;
+pub type InputId = u32;
+
+pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
+pub type ChunkStream = BoxStream<Result<Chunk, Error>>;
+pub type InputStream = BoxStream<Result<(usize, String), Error>>;
+pub type InputSender = mpsc::Sender<Result<(usize, String), Error>>;
+pub type InputReceiver = mpsc::Receiver<Result<(usize, String), Error>>;
+pub type DetectionStream = BoxStream<Result<(InputId, DetectorId, Chunk, Detections), Error>>;
+pub type GenerationStream = BoxStream<(usize, Result<ClassifiedGeneratedTextStreamResult, Error>)>;
+pub type ChatCompletionStream = BoxStream<(usize, Result<Option<ChatCompletionChunk>, Error>)>;

--- a/src/orchestrator/types/chat_message.rs
+++ b/src/orchestrator/types/chat_message.rs
@@ -26,6 +26,8 @@ pub struct ChatMessage<'a> {
     pub role: Option<&'a openai::Role>,
     /// The text contents of the message.
     pub text: Option<&'a str>,
+    /// The refusal message.
+    pub refusal: Option<&'a str>,
 }
 
 /// An iterator over chat messages.
@@ -46,6 +48,7 @@ impl ChatMessageIterator for openai::ChatCompletionsRequest {
                 index: index as u32,
                 role: Some(&message.role),
                 text,
+                refusal: message.refusal.as_deref(),
             }
         })
     }
@@ -57,6 +60,7 @@ impl ChatMessageIterator for openai::ChatCompletion {
             index: choice.index,
             role: Some(&choice.message.role),
             text: choice.message.content.as_deref(),
+            refusal: choice.message.refusal.as_deref(),
         })
     }
 }
@@ -67,6 +71,7 @@ impl ChatMessageIterator for openai::ChatCompletionChunk {
             index: choice.index,
             role: choice.delta.role.as_ref(),
             text: choice.delta.content.as_deref(),
+            refusal: choice.delta.refusal.as_deref(),
         })
     }
 }

--- a/src/orchestrator/types/chat_message.rs
+++ b/src/orchestrator/types/chat_message.rs
@@ -1,0 +1,56 @@
+use crate::clients::openai;
+
+/// A chat message.
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct ChatMessage<'a> {
+    /// Message index
+    /// Corresponds to choice index for chat completions.
+    pub index: u32,
+    /// The role of the author of this message.
+    pub role: Option<&'a openai::Role>,
+    /// The text contents of the message.
+    pub text: Option<&'a str>,
+}
+
+/// An iterator over chat messages.
+pub trait ChatMessageIterator {
+    /// Returns an iterator of [`ChatMessage`]s.
+    fn messages(&self) -> impl Iterator<Item = ChatMessage>;
+}
+
+impl ChatMessageIterator for openai::ChatCompletionsRequest {
+    fn messages(&self) -> impl Iterator<Item = ChatMessage> {
+        self.messages.iter().enumerate().map(|(index, message)| {
+            let text = if let Some(openai::Content::Text(text)) = &message.content {
+                Some(text.as_str())
+            } else {
+                None
+            };
+            ChatMessage {
+                index: index as u32,
+                role: Some(&message.role),
+                text,
+            }
+        })
+    }
+}
+
+impl ChatMessageIterator for openai::ChatCompletion {
+    fn messages(&self) -> impl Iterator<Item = ChatMessage> {
+        self.choices.iter().map(|choice| ChatMessage {
+            index: choice.index,
+            role: Some(&choice.message.role),
+            text: choice.message.content.as_deref(),
+        })
+    }
+}
+
+impl ChatMessageIterator for openai::ChatCompletionChunk {
+    fn messages(&self) -> impl Iterator<Item = ChatMessage> {
+        self.choices.iter().map(|choice| ChatMessage {
+            index: choice.index,
+            role: choice.delta.role.as_ref(),
+            text: choice.delta.content.as_deref(),
+        })
+    }
+}

--- a/src/orchestrator/types/chat_message.rs
+++ b/src/orchestrator/types/chat_message.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use crate::clients::openai;
 
 /// A chat message.

--- a/src/orchestrator/types/chunk.rs
+++ b/src/orchestrator/types/chunk.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use crate::pb::caikit_data_model::nlp as pb;
 
 /// A chunk.

--- a/src/orchestrator/types/chunk.rs
+++ b/src/orchestrator/types/chunk.rs
@@ -1,0 +1,149 @@
+use crate::pb::caikit_data_model::nlp as pb;
+
+/// A chunk.
+#[derive(Default, Debug, Clone)]
+pub struct Chunk {
+    /// Index of message where chunk begins
+    pub input_start_index: usize,
+    /// Index of message where chunk ends
+    pub input_end_index: usize,
+    /// Index of char where chunk begins
+    pub start: usize,
+    /// Index of char where chunk ends
+    pub end: usize,
+    /// Text
+    pub text: String,
+}
+
+impl PartialOrd for Chunk {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Chunk {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (
+            self.input_start_index,
+            self.input_end_index,
+            self.start,
+            self.end,
+        )
+            .cmp(&(
+                other.input_start_index,
+                other.input_end_index,
+                other.start,
+                other.end,
+            ))
+    }
+}
+
+impl PartialEq for Chunk {
+    fn eq(&self, other: &Self) -> bool {
+        (
+            self.input_start_index,
+            self.input_end_index,
+            self.start,
+            self.end,
+        ) == (
+            other.input_start_index,
+            other.input_end_index,
+            other.start,
+            other.end,
+        )
+    }
+}
+
+impl Eq for Chunk {}
+
+impl std::hash::Hash for Chunk {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.input_start_index.hash(state);
+        self.input_end_index.hash(state);
+        self.start.hash(state);
+        self.end.hash(state);
+    }
+}
+
+/// An array of chunks.
+#[derive(Default, Debug, Clone)]
+pub struct Chunks(Vec<Chunk>);
+
+impl Chunks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl std::ops::Deref for Chunks {
+    type Target = Vec<Chunk>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Chunks {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for Chunks {
+    type Item = Chunk;
+    type IntoIter = <Vec<Chunk> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl FromIterator<Chunk> for Chunks {
+    fn from_iter<T: IntoIterator<Item = Chunk>>(iter: T) -> Self {
+        let mut chunks = Chunks::new();
+        for value in iter {
+            chunks.push(value);
+        }
+        chunks
+    }
+}
+
+impl From<Vec<Chunk>> for Chunks {
+    fn from(value: Vec<Chunk>) -> Self {
+        Self(value)
+    }
+}
+
+// Conversions
+
+impl From<pb::ChunkerTokenizationStreamResult> for Chunk {
+    fn from(value: pb::ChunkerTokenizationStreamResult) -> Self {
+        let text = value
+            .results
+            .into_iter()
+            .map(|token| token.text)
+            .collect::<String>();
+        Chunk {
+            input_start_index: value.input_start_index as usize,
+            input_end_index: value.input_end_index as usize,
+            start: value.start_index as usize,
+            end: value.processed_index as usize,
+            text,
+        }
+    }
+}
+
+impl From<pb::TokenizationResults> for Chunks {
+    fn from(value: pb::TokenizationResults) -> Self {
+        value
+            .results
+            .into_iter()
+            .map(|token| Chunk {
+                start: token.start as usize,
+                end: token.end as usize,
+                text: token.text,
+                ..Default::default()
+            })
+            .collect()
+    }
+}

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -19,23 +19,35 @@ use crate::{clients::detector, models};
 /// A detection.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct Detection {
+    /// Start index of the detection
     pub start: Option<usize>,
+    /// End index of the detection
     pub end: Option<usize>,
+    /// Text corresponding to the detection
     pub text: Option<String>,
+    /// ID of the detector
     pub detector_id: Option<String>,
+    /// Type of detection
     pub detection_type: String,
+    /// Detection class
     pub detection: String,
+    /// Confidence level of the detection class
     pub score: f64,
+    /// Detection evidence
     pub evidence: Vec<DetectionEvidence>,
 }
 
 /// Detection evidence.
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct DetectionEvidence {
+    /// Evidence name
     pub name: String,
+    /// Evidence value
     pub value: Option<String>,
+    /// Evidence score
     pub score: Option<f64>,
-    pub evidence: Option<Vec<Evidence>>,
+    /// Additional evidence
+    pub evidence: Vec<Evidence>,
 }
 
 /// Additional detection evidence.
@@ -127,13 +139,13 @@ impl From<Vec<Vec<detector::ContentAnalysisResponse>>> for Detections {
 
 impl From<DetectionEvidence> for models::EvidenceObj {
     fn from(value: DetectionEvidence) -> Self {
+        let evidence = (!value.evidence.is_empty())
+            .then_some(value.evidence.into_iter().map(Into::into).collect());
         Self {
             name: value.name,
             value: value.value,
             score: value.score,
-            evidence: value
-                .evidence
-                .map(|vs| vs.into_iter().map(Into::into).collect()),
+            evidence,
         }
     }
 }
@@ -156,7 +168,8 @@ impl From<models::EvidenceObj> for DetectionEvidence {
             score: value.score,
             evidence: value
                 .evidence
-                .map(|vs| vs.into_iter().map(Into::into).collect()),
+                .map(|vs| vs.into_iter().map(Into::into).collect())
+                .unwrap_or_default(),
         }
     }
 }

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use crate::{clients::detector, models};
 
 /// A detection.

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -1,0 +1,224 @@
+use crate::{clients::detector, models};
+
+/// A detection.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct Detection {
+    pub start: Option<usize>,
+    pub end: Option<usize>,
+    pub text: Option<String>,
+    pub detector_id: Option<String>,
+    pub detection_type: String,
+    pub detection: String,
+    pub score: f64,
+    pub evidence: Vec<DetectionEvidence>,
+}
+
+/// Detection evidence.
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct DetectionEvidence {
+    pub name: String,
+    pub value: Option<String>,
+    pub score: Option<f64>,
+    pub evidence: Option<Vec<Evidence>>,
+}
+
+/// Additional detection evidence.
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct Evidence {
+    pub name: String,
+    pub value: Option<String>,
+    pub score: Option<f64>,
+}
+
+/// An array of detections.
+#[derive(Default, Debug, Clone)]
+pub struct Detections(Vec<Detection>);
+
+impl Detections {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl std::ops::Deref for Detections {
+    type Target = Vec<Detection>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Detections {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for Detections {
+    type Item = Detection;
+    type IntoIter = <Vec<Detection> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl FromIterator<Detection> for Detections {
+    fn from_iter<T: IntoIterator<Item = Detection>>(iter: T) -> Self {
+        let mut detections = Detections::new();
+        for value in iter {
+            detections.push(value);
+        }
+        detections
+    }
+}
+
+impl From<Vec<Detection>> for Detections {
+    fn from(value: Vec<Detection>) -> Self {
+        Self(value)
+    }
+}
+
+// Conversions
+
+impl From<detector::ContentAnalysisResponse> for Detection {
+    fn from(value: detector::ContentAnalysisResponse) -> Self {
+        Self {
+            start: Some(value.start),
+            end: Some(value.end),
+            text: Some(value.text),
+            detector_id: value.detector_id,
+            detection_type: value.detection_type,
+            detection: value.detection,
+            score: value.score,
+            evidence: value
+                .evidence
+                .map(|vs| vs.into_iter().map(Into::into).collect())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<Vec<Vec<detector::ContentAnalysisResponse>>> for Detections {
+    fn from(value: Vec<Vec<detector::ContentAnalysisResponse>>) -> Self {
+        value
+            .into_iter()
+            .flatten()
+            .map(|detection| detection.into())
+            .collect::<Detections>()
+    }
+}
+
+impl From<DetectionEvidence> for models::EvidenceObj {
+    fn from(value: DetectionEvidence) -> Self {
+        Self {
+            name: value.name,
+            value: value.value,
+            score: value.score,
+            evidence: value
+                .evidence
+                .map(|vs| vs.into_iter().map(Into::into).collect()),
+        }
+    }
+}
+
+impl From<Evidence> for models::Evidence {
+    fn from(value: Evidence) -> Self {
+        Self {
+            name: value.name,
+            value: value.value,
+            score: value.score,
+        }
+    }
+}
+
+impl From<models::EvidenceObj> for DetectionEvidence {
+    fn from(value: models::EvidenceObj) -> Self {
+        Self {
+            name: value.name,
+            value: value.value,
+            score: value.score,
+            evidence: value
+                .evidence
+                .map(|vs| vs.into_iter().map(Into::into).collect()),
+        }
+    }
+}
+
+impl From<models::Evidence> for Evidence {
+    fn from(value: models::Evidence) -> Self {
+        Self {
+            name: value.name,
+            value: value.value,
+            score: value.score,
+        }
+    }
+}
+
+impl From<models::DetectionResult> for Detection {
+    fn from(value: models::DetectionResult) -> Self {
+        Self {
+            start: None,
+            end: None,
+            text: None,
+            detector_id: value.detector_id,
+            detection_type: value.detection_type,
+            detection: value.detection,
+            score: value.score,
+            evidence: value
+                .evidence
+                .map(|vs| vs.into_iter().map(Into::into).collect())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<Vec<models::DetectionResult>> for Detections {
+    fn from(value: Vec<models::DetectionResult>) -> Self {
+        value.into_iter().map(Into::into).collect()
+    }
+}
+
+impl From<Detection> for models::TokenClassificationResult {
+    fn from(value: Detection) -> Self {
+        Self {
+            start: value.start.map(|v| v as u32).unwrap(),
+            end: value.end.map(|v| v as u32).unwrap(),
+            word: value.text.unwrap_or_default(),
+            entity: value.detection,
+            entity_group: value.detection_type,
+            detector_id: value.detector_id,
+            score: value.score,
+            token_count: None,
+        }
+    }
+}
+
+impl From<Detections> for Vec<models::TokenClassificationResult> {
+    fn from(value: Detections) -> Self {
+        value.into_iter().map(Into::into).collect()
+    }
+}
+
+impl From<Detection> for detector::ContentAnalysisResponse {
+    fn from(value: Detection) -> Self {
+        let evidence = (!value.evidence.is_empty())
+            .then_some(value.evidence.into_iter().map(Into::into).collect());
+        Self {
+            start: value.start.unwrap(),
+            end: value.end.unwrap(),
+            text: value.text.unwrap(),
+            detection: value.detection,
+            detection_type: value.detection_type,
+            detector_id: value.detector_id,
+            score: value.score,
+            evidence,
+        }
+    }
+}
+
+impl From<Detections> for Vec<detector::ContentAnalysisResponse> {
+    fn from(value: Detections) -> Self {
+        value.into_iter().map(Into::into).collect()
+    }
+}

--- a/src/orchestrator/types/detection_batch_stream.rs
+++ b/src/orchestrator/types/detection_batch_stream.rs
@@ -20,8 +20,12 @@ use tokio::sync::mpsc;
 use super::{DetectionBatcher, DetectionStream};
 use crate::orchestrator::Error;
 
-/// Wraps detection streams and produces a stream
-/// of batches using a [`DetectionBatcher`].
+/// A stream adapter that wraps multiple detection streams and
+/// produces a stream of batches using a [`DetectionBatcher`]
+/// implementation.
+///
+/// The detection batcher enables flexible batching
+/// logic and returned batch types for different use cases.
 pub struct DetectionBatchStream<B: DetectionBatcher> {
     batch_rx: mpsc::Receiver<Result<B::Batch, Error>>,
 }

--- a/src/orchestrator/types/detection_batch_stream.rs
+++ b/src/orchestrator/types/detection_batch_stream.rs
@@ -1,0 +1,89 @@
+use futures::{stream, Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use super::{BoxStream, Chunk, DetectionBatcher, DetectionStream, Detections, DetectorId, InputId};
+use crate::orchestrator::Error;
+
+/// Wraps detection streams and produces a stream
+/// of batches using a [`DetectionBatcher`].
+pub struct DetectionBatchStream<B: DetectionBatcher> {
+    inner: BoxStream<Result<B::Batch, Error>>,
+}
+
+impl<B> DetectionBatchStream<B>
+where
+    B: DetectionBatcher,
+{
+    pub fn new(mut batcher: B, streams: Vec<DetectionStream>) -> Self {
+        // Create batch channel
+        let (batch_tx, batch_rx) = mpsc::channel(32);
+        // Create batcher channel
+        let (batcher_tx, mut batcher_rx) =
+            mpsc::channel::<Result<(InputId, DetectorId, Chunk, Detections), Error>>(32);
+
+        // Spawn batcher task
+        // This task receives new detections, pushes them to a batcher, and sends
+        // batches to the batch (output) stream as they become ready.
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = batcher_rx.recv() => {
+                        match result {
+                            Some(Ok((input_id, detector_id, chunk, detections))) => {
+                                // Received new detections
+                                // Push detections to batcher
+                                batcher.push(input_id, detector_id, chunk, detections);
+
+                                // Check if we have any batches ready
+                                if let Some(batch) = batcher.pop_batch() {
+                                    // Send batch to batch channel
+                                    let _ = batch_tx.send(Ok(batch)).await;
+                                }
+                            },
+                            Some(Err(error)) => {
+                                // Received error
+                                // Send error to batch channel
+                                let _ = batch_tx.send(Err(error)).await;
+                                break;
+                            },
+                            None => {
+                                // Batcher stream closed
+                                // Terminate task
+                                break;
+                            },
+                        }
+                    },
+                }
+            }
+        });
+
+        // Create a stream set (a single stream) from multiple detection streams
+        let mut stream_set = stream::select_all(streams);
+
+        // Spawn detection consumer task
+        // This task consumes new detections and sends them to the batcher task.
+        tokio::spawn(async move {
+            while let Some(result) = stream_set.next().await {
+                // Received new detections
+                // Send to batcher task
+                let _ = batcher_tx.send(result).await;
+            }
+        });
+
+        Self {
+            inner: ReceiverStream::new(batch_rx).boxed(),
+        }
+    }
+}
+
+impl<T: DetectionBatcher> Stream for DetectionBatchStream<T> {
+    type Item = Result<T::Batch, Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}

--- a/src/orchestrator/types/detection_batch_stream.rs
+++ b/src/orchestrator/types/detection_batch_stream.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use futures::{stream, Stream, StreamExt};
 use tokio::sync::mpsc;
 

--- a/src/orchestrator/types/detection_batch_stream.rs
+++ b/src/orchestrator/types/detection_batch_stream.rs
@@ -65,7 +65,7 @@ where
                                 break;
                             },
                             None => {
-                                // Batcher channel closed
+                                // Detection stream set closed
                                 break;
                             },
                         }

--- a/src/orchestrator/types/detection_batcher.rs
+++ b/src/orchestrator/types/detection_batcher.rs
@@ -1,0 +1,26 @@
+pub mod chat_completion;
+pub use chat_completion::*;
+pub mod noop;
+pub use noop::*;
+pub mod max_processed_index;
+pub use max_processed_index::*;
+
+use super::{Chunk, Detections, DetectorId, InputId};
+
+/// A detection batcher.
+/// Implements pluggable batching logic for a [`DetectionBatchStream`].
+pub trait DetectionBatcher: Send + 'static {
+    type Batch: Send + 'static;
+
+    /// Pushes new detections.
+    fn push(
+        &mut self,
+        input_id: InputId,
+        detector_id: DetectorId,
+        chunk: Chunk,
+        detections: Detections,
+    );
+
+    /// Removes the next batch of detections, if ready.
+    fn pop_batch(&mut self) -> Option<Self::Batch>;
+}

--- a/src/orchestrator/types/detection_batcher.rs
+++ b/src/orchestrator/types/detection_batcher.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 pub mod chat_completion;
 pub use chat_completion::*;
 pub mod noop;

--- a/src/orchestrator/types/detection_batcher/chat_completion.rs
+++ b/src/orchestrator/types/detection_batcher/chat_completion.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 #![allow(dead_code)]
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 use crate::orchestrator::types::Chunks;

--- a/src/orchestrator/types/detection_batcher/chat_completion.rs
+++ b/src/orchestrator/types/detection_batcher/chat_completion.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code)]
+use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
+use crate::orchestrator::types::Chunks;
+
+/// A batcher for chat completions.
+pub struct ChatCompletionBatcher {
+    detectors: Vec<DetectorId>,
+    // state: TBD
+}
+
+impl ChatCompletionBatcher {
+    pub fn new(detectors: Vec<DetectorId>) -> Self {
+        // let state = TBD::new();
+        Self {
+            detectors,
+            // state,
+        }
+    }
+}
+
+impl DetectionBatcher for ChatCompletionBatcher {
+    type Batch = (u32, Chunks, Detections); // placeholder, actual type TBD
+
+    fn push(
+        &mut self,
+        _input_id: InputId,
+        _detector_id: DetectorId,
+        _chunk: Chunk,
+        _detections: Detections,
+    ) {
+        // NOTE: input_id maps to choice_index
+        todo!()
+    }
+
+    fn pop_batch(&mut self) -> Option<Self::Batch> {
+        // TODO: implement batching logic to align with requirements
+        // ref: https://github.com/foundation-model-stack/fms-guardrails-orchestrator/blob/main/docs/architecture/adrs/005-chat-completion-support.md#streaming-response
+        todo!()
+    }
+}

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -1,0 +1,62 @@
+use std::collections::{btree_map, BTreeMap};
+
+use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
+
+/// A batcher based on the original "max processed index" aggregator.
+///
+/// Each chunk is a batch, returned in-order once detections
+/// from all detectors have been received for the chunk.
+///
+/// Assumes all detectors are using the same chunker.
+pub struct MaxProcessedIndexBatcher {
+    n: usize,
+    state: BTreeMap<Chunk, Vec<Detections>>,
+}
+
+impl MaxProcessedIndexBatcher {
+    pub fn new(n: usize) -> Self {
+        Self {
+            n,
+            state: BTreeMap::default(),
+        }
+    }
+}
+
+impl DetectionBatcher for MaxProcessedIndexBatcher {
+    type Batch = (Chunk, Detections);
+
+    fn push(
+        &mut self,
+        _input_id: InputId,
+        _detector_id: DetectorId,
+        chunk: Chunk,
+        detections: Detections,
+    ) {
+        match self.state.entry(chunk) {
+            btree_map::Entry::Vacant(entry) => {
+                // New chunk, insert entry
+                entry.insert(vec![detections]);
+            }
+            btree_map::Entry::Occupied(mut entry) => {
+                // Existing chunk, push detections
+                entry.get_mut().push(detections);
+            }
+        }
+    }
+
+    fn pop_batch(&mut self) -> Option<Self::Batch> {
+        // Check if we have all detections for the next chunk
+        if self
+            .state
+            .first_key_value()
+            .is_some_and(|(_, detections)| detections.len() == self.n)
+        {
+            // We have all detections for the chunk, remove and return it.
+            if let Some((chunk, detections)) = self.state.pop_first() {
+                let detections = detections.into_iter().flatten().collect();
+                return Some((chunk, detections));
+            }
+        }
+        None
+    }
+}

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -2,12 +2,21 @@ use std::collections::{btree_map, BTreeMap};
 
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 
-/// A batcher based on the original "max processed index" aggregator.
+/// A batcher based on the original "max processed index"
+/// aggregator.
 ///
-/// Each chunk is a batch, returned in-order once detections
-/// from all detectors have been received for the chunk.
+/// A batch corresponds to a chunk. Batches are
+/// returned in-order as detections from all detectors
+/// are received for the chunk.
 ///
-/// Assumes all detectors are using the same chunker.
+/// For example, if we have n chunks with 3 detectors
+/// applied to each chunk, the first batch for chunk-1 is
+/// popped once detections from 3 detectors are received
+/// for chunk-1. The next batch for chunk-2 is popped once
+/// detections from 3 detectors are received for chunk-2,
+/// and so on.
+///
+/// This batcher requires that all detectors use the same chunker.
 pub struct MaxProcessedIndexBatcher {
     n: usize,
     state: BTreeMap<Chunk, Vec<Detections>>,
@@ -58,5 +67,85 @@ impl DetectionBatcher for MaxProcessedIndexBatcher {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::orchestrator::types::Detection;
+
+    #[test]
+    fn test_single_chunk_multiple_detectors() {
+        let input_id = 0;
+        let chunk = Chunk {
+            input_start_index: 0,
+            input_end_index: 0,
+            start: 0,
+            end: 24,
+            text: "this is a dummy sentence".into(),
+        };
+
+        // Create a batcher that will process batches for 2 detectors
+        let n = 2;
+        let mut batcher = MaxProcessedIndexBatcher::new(n);
+
+        // Push detections for pii detector
+        batcher.push(
+            input_id,
+            "pii".into(),
+            chunk.clone(),
+            vec![Detection {
+                start: Some(5),
+                end: Some(10),
+                detector_id: Some("pii".into()),
+                detection_type: "pii".into(),
+                score: 0.4,
+                ..Default::default()
+            }]
+            .into(),
+        );
+
+        // We only have detections for 1 detector
+        // pop_batch() should return None
+        assert!(batcher.pop_batch().is_none());
+
+        // Push detections for hap detector
+        batcher.push(
+            input_id,
+            "hap".into(),
+            chunk.clone(),
+            vec![
+                Detection {
+                    start: Some(5),
+                    end: Some(10),
+                    detector_id: Some("hap".into()),
+                    detection_type: "hap".into(),
+                    score: 0.8,
+                    ..Default::default()
+                },
+                Detection {
+                    start: Some(15),
+                    end: Some(20),
+                    detector_id: Some("hap".into()),
+                    detection_type: "hap".into(),
+                    score: 0.8,
+                    ..Default::default()
+                },
+            ]
+            .into(),
+        );
+
+        // We have detections for 2 detectors
+        // pop_batch() should return a batch containing 3 detections for the chunk
+        let batch = batcher.pop_batch();
+        assert!(
+            batch.is_some_and(|(chunk, detections)| { chunk == chunk && detections.len() == 3 })
+        );
+    }
+
+    #[test]
+    fn test_out_of_order_chunks() {
+        todo!()
     }
 }

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -34,14 +34,14 @@ use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 ///
 /// This batcher requires that all detectors use the same chunker.
 pub struct MaxProcessedIndexBatcher {
-    n: usize,
+    n_detectors: usize,
     state: BTreeMap<Chunk, Vec<Detections>>,
 }
 
 impl MaxProcessedIndexBatcher {
-    pub fn new(n: usize) -> Self {
+    pub fn new(n_detectors: usize) -> Self {
         Self {
-            n,
+            n_detectors,
             state: BTreeMap::default(),
         }
     }
@@ -74,7 +74,7 @@ impl DetectionBatcher for MaxProcessedIndexBatcher {
         if self
             .state
             .first_key_value()
-            .is_some_and(|(_, detections)| detections.len() == self.n)
+            .is_some_and(|(_, detections)| detections.len() == self.n_detectors)
         {
             // We have all detections for the chunk, remove and return it.
             if let Some((chunk, detections)) = self.state.pop_first() {

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -72,11 +72,20 @@ impl DetectionBatcher for MaxProcessedIndexBatcher {
 
 #[cfg(test)]
 mod test {
+    use std::task::Poll;
+
+    use futures::StreamExt;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
     use super::*;
-    use crate::orchestrator::types::Detection;
+    use crate::orchestrator::{
+        types::{Detection, DetectionBatchStream},
+        Error,
+    };
 
     #[test]
-    fn test_single_chunk_multiple_detectors() {
+    fn test_batcher_with_single_chunk() {
         let input_id = 0;
         let chunk = Chunk {
             input_start_index: 0,
@@ -145,7 +154,7 @@ mod test {
     }
 
     #[test]
-    fn test_out_of_order_chunks() {
+    fn test_batcher_with_out_of_order_chunks() {
         let input_id = 0;
         let chunks = [
             Chunk {
@@ -194,7 +203,7 @@ mod test {
             Detections::default(), // no detections
         );
 
-        // We have detections for chunk-2, but not chunk-1
+        // We have all detections for chunk-2, but not chunk-1
         // pop_batch() should return None
         assert!(batcher.pop_batch().is_none());
 
@@ -214,7 +223,7 @@ mod test {
             .into(),
         );
 
-        // We have detections for chunk-1 and chunk-2
+        // We have all detections for chunk-1 and chunk-2
         // pop_batch() should return chunk-1 with 1 pii detection
         let batch = batcher.pop_batch();
         assert!(batch
@@ -227,5 +236,128 @@ mod test {
 
         // batcher state should be empty as all batches have been returned
         assert!(batcher.state.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_detection_batch_stream() -> Result<(), Error> {
+        let input_id = 0;
+        let chunks = [
+            Chunk {
+                input_start_index: 0,
+                input_end_index: 10,
+                start: 0,
+                end: 56,
+                text: " a powerful tool for the development \
+                    of complex systems."
+                    .into(),
+            },
+            Chunk {
+                input_start_index: 11,
+                input_end_index: 26,
+                start: 56,
+                end: 135,
+                text: " It has been used in many fields, such as \
+                    computer vision and image processing."
+                    .into(),
+            },
+        ];
+
+        // Create detection channels and streams
+        let (pii_detections_tx, pii_detections_rx) =
+            mpsc::channel::<Result<(InputId, DetectorId, Chunk, Detections), Error>>(4);
+        let pii_detections_stream = ReceiverStream::new(pii_detections_rx).boxed();
+        let (hap_detections_tx, hap_detections_rx) =
+            mpsc::channel::<Result<(InputId, DetectorId, Chunk, Detections), Error>>(4);
+        let hap_detections_stream = ReceiverStream::new(hap_detections_rx).boxed();
+
+        // Create a batcher that will process batches for 2 detectors
+        let n = 2;
+        let batcher = MaxProcessedIndexBatcher::new(n);
+
+        // Create detection batch stream
+        let streams = vec![pii_detections_stream, hap_detections_stream];
+        let mut detection_batch_stream = DetectionBatchStream::new(batcher, streams);
+
+        // Send chunk-2 detections for pii detector
+        let _ = pii_detections_tx
+            .send(Ok((
+                input_id,
+                "pii".into(),
+                chunks[1].clone(),
+                Detections::default(), // no detections
+            )))
+            .await;
+
+        // Send chunk-1 detections for hap detector
+        let _ = hap_detections_tx
+            .send(Ok((
+                input_id,
+                "hap".into(),
+                chunks[0].clone(),
+                Detections::default(), // no detections
+            )))
+            .await;
+
+        // Send chunk-2 detections for hap detector
+        let _ = hap_detections_tx
+            .send(Ok((
+                input_id,
+                "hap".into(),
+                chunks[1].clone(),
+                Detections::default(), // no detections
+            )))
+            .await;
+
+        // We have all detections for chunk-2, but not chunk-1
+        // detection_batch_stream.next() future should not be ready
+        assert!(matches!(
+            futures::poll!(detection_batch_stream.next()),
+            Poll::Pending
+        ));
+
+        // Send chunk-1 detections for pii detector
+        let _ = pii_detections_tx
+            .send(Ok((
+                input_id,
+                "pii".into(),
+                chunks[0].clone(),
+                vec![Detection {
+                    start: Some(10),
+                    end: Some(20),
+                    detector_id: Some("pii".into()),
+                    detection_type: "pii".into(),
+                    score: 0.4,
+                    ..Default::default()
+                }]
+                .into(),
+            )))
+            .await;
+
+        // We have all detections for chunk-1 and chunk-2
+        // detection_batch_stream.next() should be ready and return chunk-1 with 1 pii detection
+        let batch = detection_batch_stream.next().await;
+        assert!(batch.is_some_and(|result| result
+            .is_ok_and(|(chunk, detections)| chunk == chunks[0] && detections.len() == 1)));
+
+        // detection_batch_stream.next() should be ready and return chunk-2 with no detections
+        let batch = detection_batch_stream.next().await;
+        assert!(batch.is_some_and(|result| result
+            .is_ok_and(|(chunk, detections)| chunk == chunks[1] && detections.is_empty())));
+
+        // detection_batch_stream.next() future should not be ready
+        // as detection senders have not been closed
+        assert!(matches!(
+            futures::poll!(detection_batch_stream.next()),
+            Poll::Pending
+        ));
+
+        // Drop detection senders
+        drop(pii_detections_tx);
+        drop(hap_detections_tx);
+
+        // detection_batch_stream.next() should return None
+        assert!(detection_batch_stream.next().await.is_none());
+
+        Ok(())
     }
 }

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use std::collections::{btree_map, BTreeMap};
 
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};

--- a/src/orchestrator/types/detection_batcher/noop.rs
+++ b/src/orchestrator/types/detection_batcher/noop.rs
@@ -1,3 +1,19 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
 use std::collections::VecDeque;
 
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};

--- a/src/orchestrator/types/detection_batcher/noop.rs
+++ b/src/orchestrator/types/detection_batcher/noop.rs
@@ -1,0 +1,33 @@
+use std::collections::VecDeque;
+
+use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
+
+/// A no-op batcher that doesn't actually batch.
+#[derive(Default)]
+pub struct NoopBatcher {
+    state: VecDeque<(Chunk, Detections)>,
+}
+
+impl NoopBatcher {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl DetectionBatcher for NoopBatcher {
+    type Batch = (Chunk, Detections);
+
+    fn push(
+        &mut self,
+        _input_id: InputId,
+        _detector_id: DetectorId,
+        chunk: Chunk,
+        detections: Detections,
+    ) {
+        self.state.push_back((chunk, detections));
+    }
+
+    fn pop_batch(&mut self) -> Option<Self::Batch> {
+        self.state.pop_front()
+    }
+}


### PR DESCRIPTION
No. 2 of a few small pre-refactor PRs. This PR adds a new `orchestrator.types` module, including new abstractions used in the refactored code.

### types.chunk
- `Chunk` 
  - An internal chunk, used for both unary and streaming
- `Chunks`
  - A newtype representing a vec of `Chunk`s

### types.detection
- `Detection` 
  - An internal detection, used for all detector types
- `Detections`
  - A newtype representing a vec of `Detection`s

### types.detection_batch_stream
- `DetectionBatchStream`
  - A stream adapter that wraps multiple detection streams and produces a stream of batches using one of the pluggable `DetectionBatcher` implementations below. 
  - More details to be added to this PR explaining the rationale and how this works.

### types.detection_batcher
- `DetectionBatcher`
   - A trait to implement pluggable batching logic for `DetectionBatchStream`
- `MaxProcessedIndexBatcher` 
  - A `DetectionBatcher` implementation based on the existing "max processed index" aggregator
- `ChatCompletionBatcher` 
  - A `DetectionBatcher` implementation for chat completions (placeholder, not yet implemented)
- `NoopBatcher` 
  - A `DetectionBatcher` implementation that doesn't actually batch (no-op, for testing purposes)

### types.chat_message
- `ChatMessage`
  - A internal representation of an openai chat message which can be a request message or a completion choice. This is essentially the same idea as the existing `ChatMessageInternal`, except it only is for `text` for now (keeping it simple as we don't currently support images or audio) and it holds references instead of owned values to avoid copying the original text, hence the lifetimes.
- `ChatMessageIterator`
  - An iterator over `ChatMessage`s

.. +  several type aliases