### PR TITLE
process stream-content requests as ndjson (w/jsonlines)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 anyhow = "1.0.95"
 async-trait = "0.1.85"
 axum = { version = "0.8.1", features = ["json"] }
-axum-extra = "0.10.0"
+axum-extra = {version = "0.10.0", features = ["json-lines"]}
 clap = { version = "4.5.26", features = ["derive", "env"] }
 eventsource-stream = "0.2.3"
 futures = "0.3.31"


### PR DESCRIPTION
**Story:**  [foundation-model-stack/fms-guardrails-orchestrator#294](https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/294)

## What does your PR do?
This PR processes the orchestrator stream-content endpoint request as a stream of newline-delimited JSON messages.
The axum_extra::json_lines extractor is used in the handler  to buffer, split, and deserialize messages.

Additionally, this PR adds a new error, `UnsupportedContentType` use to validate `Content-Type`, and this case, is used to enforce the content-type is application/x-ndjson in the request.

## How this was tested
This was tested locally, using the following commands to verify the content-type validation, and the output of the messages: 

Regular message: 
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/text/detection/stream-content' \
>   -H 'accept: application/x-ndjson' \
>   -H 'Content-Type: application/x-ndjson' \
>   -d '{"detectors": {"en_syntax_slate.38m.hap": {}}, "content": "hello"}'
{"detections":[],"processed_index":5,"start_index":0}
```

new-line separated messages
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/text/detection/stream-content' \
>   -H 'accept: application/x-ndjson' \
>   -H 'Content-Type: application/x-ndjson' \
>   --data-binary $'{"detectors": {"en_syntax_slate.38m.hap": {}}, "content": "hello."}\n{"content": " f*** off"}\n{"content": "right now. You are stupid."}'
{"detections":[],"processed_index":6,"start_index":0}
{"detections":[{"start":0,"end":19,"text":" f*** offright now.","detection":"has_HAP","detection_type":"hap","detector_id":"en_syntax_slate.38m.hap","score":xxx}],"processed_index":25,"start_index":6}
{"detections":[{"start":0,"end":16,"text":" You are stupid.","detection":"has_HAP","detection_type":"hap","detector_id":"en_syntax_slate.38m.hap","score":xxx}],"processed_index":41,"start_index":25}
```
Invalid content-type:
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/text/detection/stream-content' \
>   -H 'accept: application/x-ndjson' \
>   -H 'Content-Type: application/json' \
>   --data-binary $'{"detectors": {"en_syntax_slate.38m.hap": {}}, "content": "hello."}\n{"content": " f*** off"}\n{"content": "right now. You are stupid."}'
{"code":415,"details":"unsupported content type: expected application/x-ndjson"}
```