### PR TITLE
Use jsonlines as response in stream-content 

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -38,14 +38,14 @@ use axum::{
 };
 use axum_extra::{extract::WithRejection, json_lines::JsonLines};
 use futures::{
-    stream::{self, BoxStream},
+    stream::{self, BoxStream, TryStreamExt},
     Stream, StreamExt,
 };
 use hyper::body::Incoming;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use opentelemetry::trace::TraceContextExt;
 use rustls::{server::WebPkiClientVerifier, RootCertStore, ServerConfig};
-use tokio::{net::TcpListener, signal, sync::mpsc};
+use tokio::{net::TcpListener, signal};
 use tokio_rustls::TlsAcceptor;
 use tokio_stream::wrappers::ReceiverStream;
 use tower::Service;
@@ -464,37 +464,14 @@ async fn stream_content_detection(
 
     // Create task and submit to handler
     let task = StreamingContentDetectionTask::new(trace_id, headers, input_stream);
-    let mut response_stream = state
+    let response_stream = state
         .orchestrator
         .handle_streaming_content_detection(task)
-        .await;
+        .await
+        .map_err(Error::from);
 
-    // Create output stream
-    // This stream returns ND-JSON formatted messages to the client
-    // StreamingContentDetectionResponse / server::Error
-    let (output_tx, output_rx) = mpsc::channel::<Result<String, Infallible>>(32);
-    let output_stream = ReceiverStream::new(output_rx);
-
-    // Spawn task to consume response stream (typed) and send to output stream (json)
-    tokio::spawn(async move {
-        while let Some(result) = response_stream.next().await {
-            match result {
-                Ok(msg) => {
-                    let msg = utils::json::to_nd_string(&msg).unwrap();
-                    let _ = output_tx.send(Ok(msg)).await;
-                }
-                Err(error) => {
-                    // Convert orchestrator::Error to server::Error
-                    let error: Error = error.into();
-                    // server::Error doesn't impl Serialize, so we use to_json()
-                    let error_msg = utils::json::to_nd_string(&error.to_json()).unwrap();
-                    let _ = output_tx.send(Ok(error_msg)).await;
-                }
-            }
-        }
-    });
-
-    Ok(Response::new(axum::body::Body::from_stream(output_stream)))
+    // Wrap the response stream in Jsonlines
+    Ok(JsonLines::new(response_stream).into_response())
 }
 
 #[instrument(skip_all)]


### PR DESCRIPTION
## What does your PR do?
This PR updates the stream-content endpoint to use jsonlines as response, as it was already updated to use jsonlines as an extractor in the handler. 

## How this was tested
This was tested locally, using the following commands to verify the response/output worked as before:

Regular message: 
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/text/detection/stream-content' \
>   -H 'accept: application/x-ndjson' \
>   -H 'Content-Type: application/x-ndjson' \
>   -d '{"detectors": {"en_syntax_slate.38m.hap": {}}, "content": "hello"}'
{"detections":[],"processed_index":5,"start_index":0}
```

new-line separated messages
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/text/detection/stream-content' \
>   -H 'accept: application/x-ndjson' \
>   -H 'Content-Type: application/x-ndjson' \
>   --data-binary $'{"detectors": {"en_syntax_slate.38m.hap": {}}, "content": "hello."}\n{"content": " f*** off"}\n{"content": "right now. You are stupid."}'
{"detections":[],"processed_index":6,"start_index":0}
{"detections":[{"start":0,"end":19,"text":" f*** offright now.","detection":"has_HAP","detection_type":"hap","detector_id":"en_syntax_slate.38m.hap","score":xxx}],"processed_index":25,"start_index":6}
{"detections":[{"start":0,"end":16,"text":" You are stupid.","detection":"has_HAP","detection_type":"hap","detector_id":"en_syntax_slate.38m.hap","score":xxx}],"processed_index":41,"start_index":25}
```
Invalid content-type:
```
curl -X 'POST' \
>   'http://localhost:8033/api/v2/text/detection/stream-content' \
>   -H 'accept: application/x-ndjson' \
>   -H 'Content-Type: application/json' \
>   --data-binary $'{"detectors": {"en_syntax_slate.38m.hap": {}}, "content": "hello."}\n{"content": " f*** off"}\n{"content": "right now. You are stupid."}'
{"code":415,"details":"unsupported content type: expected application/x-ndjson"}
```

