### PR TITLE
Refactor TestOrchestratorServerBuilder and TestOrchestratorServer to avoid mock server ownership

### DIFF
--- a/tests/detection_content.rs
+++ b/tests/detection_content.rs
@@ -79,7 +79,7 @@ async fn test_single_detection_whole_doc() -> Result<(), anyhow::Error> {
     let mock_detector_server = HttpMockServer::new(detector_name, mocks)?;
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .detector_servers([mock_detector_server])
+        .detector_servers([&mock_detector_server])
         .build()
         .await?;
 
@@ -186,8 +186,8 @@ async fn test_single_detection_sentence_chunker() -> Result<(), anyhow::Error> {
     let mock_detector_server = HttpMockServer::new(detector_name, mocks)?;
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .detector_servers([mock_detector_server])
-        .chunker_servers([mock_chunker_server])
+        .detector_servers([&mock_detector_server])
+        .chunker_servers([&mock_chunker_server])
         .build()
         .await?;
 

--- a/tests/streaming_classification_with_gen_nlp.rs
+++ b/tests/streaming_classification_with_gen_nlp.rs
@@ -120,7 +120,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .generation_server(generation_server)
+        .generation_server(&generation_server)
         .build()
         .await?;
 
@@ -246,9 +246,9 @@ async fn input_detector_no_detections() -> Result<(), anyhow::Error> {
     let generation_server = GrpcMockServer::new("nlp", generation_mocks)?;
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .generation_server(generation_server)
-        .detector_servers([mock_detector_server])
-        .chunker_servers([mock_chunker_server])
+        .generation_server(&generation_server)
+        .detector_servers([&mock_detector_server])
+        .chunker_servers([&mock_chunker_server])
         .build()
         .await?;
 
@@ -383,9 +383,9 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
     let generation_server = GrpcMockServer::new("nlp", generation_mocks)?;
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .generation_server(generation_server)
-        .detector_servers([mock_detector_server])
-        .chunker_servers([mock_chunker_server])
+        .generation_server(&generation_server)
+        .detector_servers([&mock_detector_server])
+        .chunker_servers([&mock_chunker_server])
         .build()
         .await?;
 
@@ -551,9 +551,9 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
     let mock_generation_server = GrpcMockServer::new("nlp", generation_mocks)?;
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .chunker_servers([mock_chunker_server])
-        .detector_servers([mock_detector_server])
-        .generation_server(mock_generation_server)
+        .chunker_servers([&mock_chunker_server])
+        .detector_servers([&mock_detector_server])
+        .generation_server(&mock_generation_server)
         .build()
         .await?;
 


### PR DESCRIPTION
As mocktail now supports mutating mocks on the server at runtime, e.g.

```rust
server.mocks().clear();
server.mocks().insert(...);
server.mocks().entry(...);
server.mocks().remove(...);
```

The initial approach to passing ownership of the `MockServer`s to the `TestOrchestratorServerBuilder` and subsequently `TestOrchestratorServer`, makes calling these methods tricky for integration tests. This PR introduces changes to only pass references to the builder. Existing tests have been updated accordingly.