### PR TITLE
:memo: API update - add tools to chat detections

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -243,6 +243,15 @@ components:
             allOf:
               - $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionRequestMessage
               - type: object
+        tools:
+          type: array
+          description: >
+            From OpenAI, A list of tools the model may call. Currently, only functions
+            are supported as a tool. Use this to provide a list of functions
+            the model may generate JSON inputs for. A max of 128 functions
+            are supported.
+          items:
+            $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionTool
         detector_params:
           type: object
           default: {}

--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -497,6 +497,15 @@ components:
             allOf:
               - $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionRequestMessage
               - type: object
+        tools:
+          type: array
+          description: >
+            From OpenAI, A list of tools the model may call. Currently, only functions
+            are supported as a tool. Use this to provide a list of functions
+            the model may generate JSON inputs for. A max of 128 functions
+            are supported.
+          items:
+            $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionTool
       additionalProperties: false
       required: ["detectors", "messages"]
       type: object


### PR DESCRIPTION
This will allow for detections with tools e.g. https://github.com/foundation-model-stack/vllm-detector-adapter/issues/36. `tools` are already part of OpenAI's `tools` on chat completion requests