### PR TITLE
reverted response_stream processing and message json conversion for stream content detection

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use hyper::Uri;
 use url::Url;
 
+pub mod json;
 pub mod tls;
 pub mod trace;
 

--- a/src/utils/json.rs
+++ b/src/utils/json.rs
@@ -1,0 +1,18 @@
+use serde::Serialize;
+
+/// Serialize the given data structure as a String of ND-JSON.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+#[inline]
+pub fn to_nd_string<T>(value: &T) -> Result<String, serde_json::Error>
+where
+    T: ?Sized + Serialize,
+{
+    let mut bytes = serde_json::to_vec(value)?;
+    bytes.push(b'\n');
+    let string = unsafe { String::from_utf8_unchecked(bytes) };
+    Ok(string)
+}

--- a/tests/canary_test.rs
+++ b/tests/canary_test.rs
@@ -20,7 +20,6 @@
 // For more: https://github.com/rust-lang/rust/issues/46379
 
 use std::sync::Arc;
-use test_log::test;
 
 use axum_test::TestServer;
 use common::orchestrator::ensure_global_rustls_state;
@@ -31,6 +30,7 @@ use fms_guardrails_orchestr8::{
 };
 use hyper::StatusCode;
 use serde_json::Value;
+use test_log::test;
 use tokio::sync::OnceCell;
 use tracing::debug;
 

--- a/tests/text_content_detection.rs
+++ b/tests/text_content_detection.rs
@@ -15,9 +15,7 @@
 
 */
 
-use serde_json::json;
 use std::collections::HashMap;
-use test_log::test;
 
 use common::{
     chunker::{CHUNKER_NAME_SENTENCE, CHUNKER_UNARY_ENDPOINT},
@@ -44,6 +42,8 @@ use fms_guardrails_orchestr8::{
 };
 use hyper::StatusCode;
 use mocktail::prelude::*;
+use serde_json::json;
+use test_log::test;
 use tracing::debug;
 
 pub mod common;


### PR DESCRIPTION
This PR reverts the response stream handling for the stream content detection to remove the bug introduced during validation for the detectors field when jsonlines was used as response.

The bug was seen with the following request: 
```
curl -X 'POST' \
  'http://localhost:8033/api/v2/text/detection/stream-content' \
  -H 'accept: application/x-ndjson' \
  -H 'Content-Type: application/x-ndjson' \
  -d '{"content": "hello"}'
curl: (18) transfer closed with outstanding read data remaining
```

The expected response is the following: 
`{'code': 422, 'details': '`detectors` is required for the first message'}`

The problem is how processing of the errors occurs in jsonlines which requires prior error mapping and serialization. Going back to the original code will remove the regressive behavior. 