### PR TITLE
pre-refactor: Add common.tasks and common.clients modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 anyhow = "1.0.95"
 async-trait = "0.1.85"
 axum = { version = "0.8.1", features = ["json"] }
-axum-extra = {version = "0.10.0", features = ["json-lines"]}
+axum-extra = { version = "0.10.0", features = ["json-lines"] }
 bytes = "1.10.0"
 clap = { version = "4.5.26", features = ["derive", "env"] }
 eventsource-stream = "0.2.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,8 +25,17 @@ use tracing::{debug, error, info, warn};
 
 use crate::clients::{chunker::DEFAULT_CHUNKER_ID, is_valid_hostname};
 
-// Placeholder to add default allowed headers
+/// Default allowed headers to passthrough to clients.
 const DEFAULT_ALLOWED_HEADERS: &[&str] = &[];
+
+/// Default number of chunker requests to send concurrently for a task.
+const fn default_detector_concurrent_requests() -> usize {
+    5
+}
+/// Default number of detector requests to send concurrently for a task.
+const fn default_chunker_concurrent_requests() -> usize {
+    5
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -189,6 +198,12 @@ pub struct OrchestratorConfig {
     // List of header keys allowed to be passed to downstream servers
     #[serde(default)]
     pub passthrough_headers: HashSet<String>,
+    /// Number of detector requests to send concurrently for a task.
+    #[serde(default = "default_detector_concurrent_requests")]
+    pub detector_concurrent_requests: usize,
+    /// Number of chunker requests to send concurrently for a task.
+    #[serde(default = "default_chunker_concurrent_requests")]
+    pub chunker_concurrent_requests: usize,
 }
 
 impl OrchestratorConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,6 +358,20 @@ impl OrchestratorConfig {
             .get(detector_id)
             .map(|detector_config| detector_config.chunker_id.clone())
     }
+
+    /// Gets a chunker config.
+    pub fn chunker(&self, chunker_id: &str) -> Option<&ChunkerConfig> {
+        if let Some(chunkers) = &self.chunkers {
+            chunkers.get(chunker_id)
+        } else {
+            None
+        }
+    }
+
+    /// Gets a detector config.
+    pub fn detector(&self, detector_id: &str) -> Option<&DetectorConfig> {
+        self.detectors.get(detector_id)
+    }
 }
 
 /// Applies named TLS config to a service.

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,7 +181,6 @@ pub enum DetectorType {
 }
 
 /// Overall orchestrator server configuration
-#[cfg_attr(test, derive(Default))]
 #[derive(Clone, Debug, Deserialize)]
 pub struct OrchestratorConfig {
     /// Generation service and associated configuration, can be omitted if configuring for generation is not wanted
@@ -379,6 +378,21 @@ impl OrchestratorConfig {
     /// Gets a detector config.
     pub fn detector(&self, detector_id: &str) -> Option<&DetectorConfig> {
         self.detectors.get(detector_id)
+    }
+}
+
+impl Default for OrchestratorConfig {
+    fn default() -> Self {
+        Self {
+            generation: None,
+            chat_generation: None,
+            chunkers: None,
+            detectors: HashMap::default(),
+            tls: None,
+            passthrough_headers: HashSet::default(),
+            detector_concurrent_requests: default_detector_concurrent_requests(),
+            chunker_concurrent_requests: default_chunker_concurrent_requests(),
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ pub enum Error {
 
 /// Configuration for service needed for
 /// orchestrator to communicate with it
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct ServiceConfig {
     /// Hostname for service
     pub hostname: String,
@@ -90,8 +90,7 @@ pub enum Tls {
 }
 
 /// Client TLS configuration
-#[cfg_attr(test, derive(Default))]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct TlsConfig {
     pub cert_path: Option<PathBuf>,
     pub key_path: Option<PathBuf>,
@@ -100,10 +99,9 @@ pub struct TlsConfig {
 }
 
 /// Generation service provider
-#[cfg_attr(test, derive(Default))]
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Default, Clone, Copy, Debug, Deserialize)]
 pub enum GenerationProvider {
-    #[cfg_attr(test, default)]
+    #[default]
     #[serde(rename = "tgis")]
     Tgis,
     #[serde(rename = "nlp")]
@@ -111,8 +109,7 @@ pub enum GenerationProvider {
 }
 
 /// Generation service configuration
-#[cfg_attr(test, derive(Default))]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct GenerationConfig {
     /// Generation service provider
     pub provider: GenerationProvider,
@@ -121,8 +118,7 @@ pub struct GenerationConfig {
 }
 
 /// Chat generation service configuration
-#[cfg_attr(test, derive(Default))]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct ChatGenerationConfig {
     /// Generation service connection information
     pub service: ServiceConfig,
@@ -131,19 +127,16 @@ pub struct ChatGenerationConfig {
 }
 
 /// Chunker parser type
-#[cfg_attr(test, derive(Default))]
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Default, Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ChunkerType {
-    #[cfg_attr(test, default)]
+    #[default]
     Sentence,
     All,
 }
 
 /// Configuration for each chunker
-#[cfg_attr(test, derive(Default))]
-#[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct ChunkerConfig {
     /// Chunker type
     pub r#type: ChunkerType,
@@ -152,7 +145,7 @@ pub struct ChunkerConfig {
 }
 
 /// Configuration for each detector
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 pub struct DetectorConfig {
     /// Detector service connection information
     pub service: ServiceConfig,
@@ -167,7 +160,7 @@ pub struct DetectorConfig {
     pub r#type: DetectorType,
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Default, Clone, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum DetectorType {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,11 +28,11 @@ use crate::clients::{chunker::DEFAULT_CHUNKER_ID, is_valid_hostname};
 /// Default allowed headers to passthrough to clients.
 const DEFAULT_ALLOWED_HEADERS: &[&str] = &[];
 
-/// Default number of chunker requests to send concurrently for a task.
+/// Default number of detector requests to send concurrently for a task.
 const fn default_detector_concurrent_requests() -> usize {
     5
 }
-/// Default number of detector requests to send concurrently for a task.
+/// Default number of chunker requests to send concurrently for a task.
 const fn default_chunker_concurrent_requests() -> usize {
     5
 }

--- a/src/orchestrator/chat_completions_detection.rs
+++ b/src/orchestrator/chat_completions_detection.rs
@@ -181,7 +181,7 @@ impl Orchestrator {
                 let chat_completions = client
                     .chat_completions(chat_request, headers)
                     .await
-                    .map_err(|error| Error::ChatGenerateRequestFailed {
+                    .map_err(|error| Error::ChatCompletionRequestFailed {
                         id: model_id.clone(),
                         error,
                     })?;

--- a/src/orchestrator/common.rs
+++ b/src/orchestrator/common.rs
@@ -16,3 +16,7 @@
 */
 pub mod utils;
 pub use utils::*;
+pub mod tasks;
+pub use tasks::*;
+pub mod client;
+pub use client::*;

--- a/src/orchestrator/common/client.rs
+++ b/src/orchestrator/common/client.rs
@@ -219,7 +219,7 @@ pub async fn chat_completion(
     Ok(response)
 }
 
-/// Sends request to openai chat completions client.
+/// Sends stream request to openai chat completions client.
 #[instrument(skip_all, fields(model_id))]
 pub async fn chat_completion_stream(
     client: &OpenAiClient,

--- a/src/orchestrator/common/client.rs
+++ b/src/orchestrator/common/client.rs
@@ -254,6 +254,7 @@ pub async fn tokenize(
     model_id: String,
     text: String,
 ) -> Result<(u32, Vec<String>), Error> {
+    // (token_count, tokens)
     debug!(%model_id, "sending tokenize request");
     let response = client
         .tokenize(model_id.clone(), text, headers)

--- a/src/orchestrator/common/client.rs
+++ b/src/orchestrator/common/client.rs
@@ -67,7 +67,7 @@ pub async fn chunk(
 pub async fn chunk_stream(
     client: &ChunkerClient,
     chunker_id: ChunkerId,
-    input_rx: broadcast::Receiver<Result<(usize, String), Error>>,
+    input_rx: broadcast::Receiver<Result<(usize, String), Error>>, // (message_index, text)
 ) -> Result<ChunkStream, Error> {
     let input_stream = BroadcastStream::new(input_rx)
         .map(|result| {

--- a/src/orchestrator/common/client.rs
+++ b/src/orchestrator/common/client.rs
@@ -1,0 +1,314 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+//! Client helpers
+use futures::{StreamExt, TryStreamExt};
+use http::HeaderMap;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::{BroadcastStream, ReceiverStream};
+use tracing::{debug, instrument};
+
+use crate::{
+    clients::{
+        chunker::ChunkerClient,
+        detector::{
+            ChatDetectionRequest, ContentAnalysisRequest, ContextDocsDetectionRequest, ContextType,
+            GenerationDetectionRequest, TextChatDetectorClient, TextContextDocDetectorClient,
+            TextGenerationDetectorClient,
+        },
+        openai::{self, ChatCompletionsResponse, OpenAiClient},
+        GenerationClient, TextContentsDetectorClient,
+    },
+    models::{
+        ClassifiedGeneratedTextResult as GenerateResponse, DetectorParams,
+        GuardrailsTextGenerationParameters as GenerateParams,
+    },
+    orchestrator::{types::*, Error},
+    pb::caikit::runtime::chunkers::{
+        BidiStreamingChunkerTokenizationTaskRequest, ChunkerTokenizationTaskRequest,
+    },
+};
+
+/// Sends request to chunker client.
+#[instrument(skip_all, fields(chunker_id))]
+pub async fn chunk(
+    client: &ChunkerClient,
+    chunker_id: ChunkerId,
+    text: String,
+) -> Result<Chunks, Error> {
+    let request = ChunkerTokenizationTaskRequest { text };
+    debug!(%chunker_id, ?request, "sending chunker request");
+    let response = client
+        .tokenization_task_predict(&chunker_id, request)
+        .await
+        .map_err(|error| Error::ChunkerRequestFailed {
+            id: chunker_id.clone(),
+            error,
+        })?;
+    debug!(%chunker_id, ?response, "received chunker response");
+    Ok(response.into())
+}
+
+/// Sends chunk stream request to chunker client.
+#[instrument(skip_all, fields(chunker_id))]
+pub async fn chunk_stream(
+    client: &ChunkerClient,
+    chunker_id: ChunkerId,
+    input_rx: broadcast::Receiver<Result<(usize, String), Error>>,
+) -> Result<ChunkStream, Error> {
+    let input_stream = BroadcastStream::new(input_rx)
+        .map(|result| {
+            let (index, text) = result.unwrap().unwrap();
+            BidiStreamingChunkerTokenizationTaskRequest {
+                text_stream: text,
+                input_index_stream: index as i64,
+            }
+        })
+        .boxed();
+    debug!(%chunker_id, "sending chunk stream request");
+    let output_stream = client
+        .bidi_streaming_tokenization_task_predict(&chunker_id, input_stream)
+        .await
+        .map_err(|error| Error::ChunkerRequestFailed {
+            id: chunker_id.clone(),
+            error,
+        })? // maps method call errors
+        .map_ok(Into::into)
+        .map_err(move |error| Error::ChunkerRequestFailed {
+            id: chunker_id.clone(),
+            error,
+        }) // maps stream errors
+        .boxed();
+    Ok(output_stream)
+}
+
+/// Sends request to text contents detector client.
+#[instrument(skip_all, fields(detector_id))]
+pub async fn detect_text_contents(
+    client: &TextContentsDetectorClient,
+    headers: HeaderMap,
+    detector_id: DetectorId,
+    params: DetectorParams,
+    chunks: Chunks,
+) -> Result<Detections, Error> {
+    let detector_id = detector_id.clone();
+    let contents = chunks
+        .into_iter()
+        .map(|chunk| chunk.text)
+        .collect::<Vec<_>>();
+    if contents.is_empty() {
+        return Ok(Detections::default());
+    }
+    let request = ContentAnalysisRequest::new(contents, params);
+    debug!(%detector_id, ?request, "sending detector request");
+    let response = client
+        .text_contents(&detector_id, request, headers)
+        .await
+        .map_err(|error| Error::DetectorRequestFailed {
+            id: detector_id.clone(),
+            error,
+        })?;
+    debug!(%detector_id, ?response, "received detector response");
+    Ok(response.into())
+}
+
+/// Sends request to text generation detector client.
+#[instrument(skip_all, fields(detector_id))]
+pub async fn detect_text_generation(
+    client: &TextGenerationDetectorClient,
+    headers: HeaderMap,
+    detector_id: DetectorId,
+    params: DetectorParams,
+    prompt: String,
+    generated_text: String,
+) -> Result<Detections, Error> {
+    let detector_id = detector_id.clone();
+    let request = GenerationDetectionRequest::new(prompt, generated_text, params);
+    debug!(%detector_id, ?request, "sending detector request");
+    let response = client
+        .text_generation(&detector_id, request, headers)
+        .await
+        .map_err(|error| Error::DetectorRequestFailed {
+            id: detector_id.clone(),
+            error,
+        })?;
+    debug!(%detector_id, ?response, "received detector response");
+    Ok(response.into())
+}
+
+/// Sends request to text chat detector client.
+#[instrument(skip_all, fields(detector_id))]
+pub async fn detect_text_chat(
+    client: &TextChatDetectorClient,
+    headers: HeaderMap,
+    detector_id: DetectorId,
+    params: DetectorParams,
+    messages: Vec<openai::Message>,
+) -> Result<Detections, Error> {
+    let detector_id = detector_id.clone();
+    let request = ChatDetectionRequest::new(messages, params);
+    debug!(%detector_id, ?request, "sending detector request");
+    let response = client
+        .text_chat(&detector_id, request, headers)
+        .await
+        .map_err(|error| Error::DetectorRequestFailed {
+            id: detector_id.clone(),
+            error,
+        })?;
+    debug!(%detector_id, ?response, "received detector response");
+    Ok(response.into())
+}
+
+/// Sends request to text context detector client.
+#[instrument(skip_all, fields(detector_id))]
+pub async fn detect_text_context(
+    client: &TextContextDocDetectorClient,
+    headers: HeaderMap,
+    detector_id: DetectorId,
+    params: DetectorParams,
+    content: String,
+    context_type: ContextType,
+    context: Vec<String>,
+) -> Result<Detections, Error> {
+    let detector_id = detector_id.clone();
+    let request = ContextDocsDetectionRequest::new(content, context_type, context, params.clone());
+    debug!(%detector_id, ?request, "sending detector request");
+    let response = client
+        .text_context_doc(&detector_id, request, headers)
+        .await
+        .map_err(|error| Error::DetectorRequestFailed {
+            id: detector_id.clone(),
+            error,
+        })?;
+    debug!(%detector_id, ?response, "received detector response");
+    Ok(response.into())
+}
+
+/// Sends request to openai chat completions client.
+#[instrument(skip_all, fields(model_id))]
+pub async fn chat_completion(
+    client: &OpenAiClient,
+    headers: HeaderMap,
+    mut request: openai::ChatCompletionsRequest,
+) -> Result<openai::ChatCompletionsResponse, Error> {
+    request.stream = false;
+    request.detectors = None;
+    let model_id = request.model.clone();
+    debug!(%model_id, ?request, "sending chat completions request");
+    let response = client
+        .chat_completions(request, headers)
+        .await
+        .map_err(|error| Error::ChatCompletionRequestFailed {
+            id: model_id.clone(),
+            error,
+        })?;
+    debug!(%model_id, ?response, "received chat completions response");
+    Ok(response)
+}
+
+/// Sends request to openai chat completions client.
+#[instrument(skip_all, fields(model_id))]
+pub async fn chat_completion_stream(
+    client: &OpenAiClient,
+    headers: HeaderMap,
+    mut request: openai::ChatCompletionsRequest,
+) -> Result<ChatCompletionStream, Error> {
+    request.stream = true;
+    request.detectors = None;
+    let model_id = request.model.clone();
+    debug!(%model_id, ?request, "sending chat completions stream request");
+    let response = client
+        .chat_completions(request, headers)
+        .await
+        .map_err(|error| Error::ChatCompletionRequestFailed {
+            id: model_id.clone(),
+            error,
+        })?;
+    let stream = match response {
+        ChatCompletionsResponse::Streaming(rx) => ReceiverStream::new(rx),
+        ChatCompletionsResponse::Unary(_) => unimplemented!(),
+    }
+    .enumerate()
+    .boxed();
+    Ok(stream)
+}
+
+/// Sends tokenize request to generation client.
+#[instrument(skip_all, fields(model_id))]
+pub async fn tokenize(
+    client: &GenerationClient,
+    headers: HeaderMap,
+    model_id: String,
+    text: String,
+) -> Result<(u32, Vec<String>), Error> {
+    debug!(%model_id, "sending tokenize request");
+    let response = client
+        .tokenize(model_id.clone(), text, headers)
+        .await
+        .map_err(|error| Error::TokenizeRequestFailed {
+            id: model_id.clone(),
+            error,
+        })?;
+    debug!(%model_id, ?response, "received tokenize response");
+    Ok(response)
+}
+
+/// Sends generate request to generation client.
+#[instrument(skip_all, fields(model_id))]
+pub async fn generate(
+    client: &GenerationClient,
+    headers: HeaderMap,
+    model_id: String,
+    text: String,
+    params: Option<GenerateParams>,
+) -> Result<GenerateResponse, Error> {
+    debug!(%model_id, "sending generate request");
+    let response = client
+        .generate(model_id.clone(), text, params, headers)
+        .await
+        .map_err(|error| Error::GenerateRequestFailed {
+            id: model_id.clone(),
+            error,
+        })?;
+    debug!(%model_id, ?response, "received generate response");
+    Ok(response)
+}
+
+/// Sends generate stream request to generation client.
+#[instrument(skip_all, fields(model_id))]
+pub async fn generate_stream(
+    client: &GenerationClient,
+    headers: HeaderMap,
+    model_id: String,
+    text: String,
+    params: Option<GenerateParams>,
+) -> Result<GenerationStream, Error> {
+    debug!(%model_id, "sending generate stream request");
+    let stream = client
+        .generate_stream(model_id.clone(), text, params, headers)
+        .await
+        .map_err(|error| Error::GenerateRequestFailed {
+            id: model_id.clone(),
+            error,
+        })? // maps method call errors
+        .map_err(move |error| Error::GenerateRequestFailed {
+            id: model_id.clone(),
+            error,
+        }) // maps stream errors
+        .enumerate()
+        .boxed();
+    Ok(stream)
+}

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -679,7 +679,7 @@ mod test {
         Arc::new(Context::new(config, clients))
     }
 
-    #[test_log::test(tokio::test)]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_chunks() -> Result<(), Error> {
         let ctx = CONTEXT.get_or_init(init_context).await;
 
@@ -778,7 +778,7 @@ mod test {
         Ok(())
     }
 
-    #[test_log::test(tokio::test)]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_text_contents_detections() -> Result<(), Error> {
         let ctx = CONTEXT.get_or_init(init_context).await;
 

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -1,0 +1,461 @@
+/*
+ Copyright FMS Guardrails Orchestrator Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/
+//! Processing tasks
+use std::{collections::HashMap, sync::Arc};
+
+use futures::{stream, StreamExt, TryStreamExt};
+use http::HeaderMap;
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, instrument};
+
+use super::{client::*, utils::*};
+use crate::{
+    clients::{
+        chunker::{ChunkerClient, DEFAULT_CHUNKER_ID},
+        detector::{
+            ContextType, TextChatDetectorClient, TextContextDocDetectorClient,
+            TextGenerationDetectorClient,
+        },
+        openai, TextContentsDetectorClient,
+    },
+    models::DetectorParams,
+    orchestrator::{types::*, Context, Error},
+};
+
+/// Spawns chunk tasks. Returns a map of chunks.
+#[instrument(skip_all)]
+pub async fn chunks(
+    ctx: Arc<Context>,
+    chunkers: Vec<ChunkerId>,
+    inputs: Vec<(usize, String)>, // (offset, text)
+) -> Result<HashMap<ChunkerId, Chunks>, Error> {
+    fn whole_doc_chunk(offset: usize, text: String) -> Chunks {
+        vec![Chunk {
+            start: offset,
+            end: text.chars().count() + offset,
+            text,
+            ..Default::default()
+        }]
+        .into()
+    }
+    let inputs = chunkers
+        .iter()
+        .flat_map(|chunker_id| {
+            inputs
+                .iter()
+                .map(|(offset, text)| (chunker_id.clone(), *offset, text.clone()))
+        })
+        .collect::<Vec<_>>();
+    let results = stream::iter(inputs)
+        .map(|(chunker_id, offset, text)| {
+            let ctx = ctx.clone();
+            async move {
+                if chunker_id == DEFAULT_CHUNKER_ID {
+                    debug!("using whole doc chunker");
+                    // Return single chunk
+                    return Ok((chunker_id, whole_doc_chunk(offset, text)));
+                }
+                let client = ctx.clients.get_as::<ChunkerClient>(&chunker_id).unwrap();
+                let chunks = chunk(client, chunker_id.clone(), text)
+                    .await?
+                    .into_iter()
+                    .map(|mut chunk| {
+                        chunk.start += offset;
+                        chunk.end += offset;
+                        chunk
+                    })
+                    .collect();
+                Ok::<_, Error>((chunker_id, chunks))
+            }
+        })
+        .buffer_unordered(8)
+        .try_collect::<HashMap<_, _>>()
+        .await?;
+    Ok(results)
+}
+
+/// Spawns chunk streaming tasks.
+/// Returns a map of chunk broadcast channels.
+#[instrument(skip_all)]
+pub async fn chunk_streams(
+    ctx: Arc<Context>,
+    chunkers: Vec<ChunkerId>,
+    input_rx: InputReceiver,
+) -> Result<HashMap<ChunkerId, broadcast::Sender<Result<Chunk, Error>>>, Error> {
+    // TODO: Drop support for this as it collects the entire input stream
+    fn whole_doc_chunk_stream(
+        mut input_broadcast_rx: broadcast::Receiver<Result<(usize, String), Error>>,
+    ) -> Result<ChunkStream, Error> {
+        // Create output channel
+        let (output_tx, output_rx) = mpsc::channel(1);
+        // Spawn task to collect input channel
+        tokio::spawn(async move {
+            // Collect input channel
+            // Alternatively, wrap receiver in BroadcastStream and collect() via StreamExt
+            let mut inputs = Vec::new();
+            while let Ok(input) = input_broadcast_rx.recv().await.unwrap() {
+                inputs.push(input);
+            }
+            // Build chunk
+            let (indices, text): (Vec<_>, Vec<_>) = inputs.into_iter().unzip();
+            let text = text.concat();
+            let chunk = Chunk {
+                input_start_index: 0,
+                input_end_index: indices.last().copied().unwrap_or_default(),
+                start: 0,
+                end: text.chars().count(),
+                text,
+            };
+            // Send chunk to output channel
+            let _ = output_tx.send(Ok::<_, Error>(chunk)).await;
+        });
+
+        Ok::<_, Error>(ReceiverStream::new(output_rx).boxed())
+    }
+
+    // Create input broadcast channel
+    let input_stream = ReceiverStream::new(input_rx).boxed();
+    let input_broadcast_tx = broadcast_stream(input_stream);
+
+    // Create chunk broadcast channels for each chunker
+    let mut streams = Vec::with_capacity(chunkers.len());
+    for chunker_id in chunkers {
+        // Subscribe to input broadcast channel
+        let input_broadcast_rx = input_broadcast_tx.subscribe();
+        // Open chunk stream
+        let chunk_stream = if chunker_id == DEFAULT_CHUNKER_ID {
+            debug!("using whole doc chunker");
+            whole_doc_chunk_stream(input_broadcast_rx)
+        } else {
+            let client = ctx.clients.get_as::<ChunkerClient>(&chunker_id).unwrap();
+            chunk_stream(client, chunker_id.clone(), input_broadcast_rx).await
+        }?;
+        // Create chunk broadcast channel
+        let chunk_broadcast_tx = broadcast_stream(chunk_stream);
+        streams.push((chunker_id, chunk_broadcast_tx));
+    }
+
+    // Return a map of chunker_id->chunker_broadcast_tx
+    Ok(streams.into_iter().collect())
+}
+
+/// Spawns text contents detection tasks.
+/// Returns a vec of detections.
+#[instrument(skip_all)]
+pub async fn text_contents_detections(
+    ctx: Arc<Context>,
+    headers: HeaderMap,
+    detectors: HashMap<String, DetectorParams>,
+    input_id: InputId,
+    inputs: Vec<(usize, String)>,
+) -> Result<(InputId, Detections), Error> {
+    let chunkers = get_chunker_ids(&ctx, &detectors)?;
+    let chunks = chunks(ctx.clone(), chunkers, inputs).await?;
+    let inputs = detectors
+        .iter()
+        .map(|(detector_id, params)| {
+            let config = ctx
+                .config
+                .detector(detector_id)
+                .ok_or_else(|| Error::DetectorNotFound(detector_id.clone()))?;
+            let chunks = chunks.get(&config.chunker_id).unwrap().clone();
+            Ok::<_, Error>((detector_id.clone(), params.clone(), chunks))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let results = stream::iter(inputs)
+        .map(|(detector_id, mut params, chunks)| {
+            let ctx = ctx.clone();
+            let headers = headers.clone();
+            let threshold = params.pop_threshold().unwrap_or_default();
+            async move {
+                let client = ctx
+                    .clients
+                    .get_as::<TextContentsDetectorClient>(&detector_id)
+                    .unwrap();
+                let detections =
+                    detect_text_contents(client, headers, detector_id.clone(), params, chunks)
+                        .await?
+                        .into_iter()
+                        .filter(|detection| detection.score >= threshold)
+                        .map(|mut detection| {
+                            detection.detector_id = Some(detector_id.clone());
+                            detection
+                        })
+                        .collect::<Detections>();
+                Ok::<_, Error>(detections)
+            }
+        })
+        .buffer_unordered(8)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let mut detections = results.into_iter().flatten().collect::<Detections>();
+    detections.sort_by_key(|detection| detection.start);
+    Ok((input_id, detections))
+}
+
+/// Spawns text contents detection stream tasks.
+/// Returns a vec of detection streams.
+#[instrument(skip_all)]
+pub async fn text_contents_detection_streams(
+    ctx: Arc<Context>,
+    headers: HeaderMap,
+    detectors: &HashMap<String, DetectorParams>,
+    input_id: InputId,
+    input_rx: InputReceiver,
+) -> Result<Vec<DetectionStream>, Error> {
+    // Create chunk streams
+    let chunkers = get_chunker_ids(&ctx, detectors)?;
+    let chunk_streams = chunk_streams(ctx.clone(), chunkers, input_rx).await?;
+    // Create detection streams
+    let mut streams = Vec::with_capacity(detectors.len());
+    for (detector_id, params) in detectors {
+        let ctx = ctx.clone();
+        let headers = headers.clone();
+        let detector_id = detector_id.clone();
+        let params = params.clone();
+        let chunker_id = ctx.config.get_chunker_id(&detector_id).unwrap();
+        // Subscribe to chunk broadcast channel
+        let mut chunk_rx = chunk_streams.get(&chunker_id).unwrap().subscribe();
+        // Create detection channel
+        let (detection_tx, detection_rx) = mpsc::channel(32);
+        // Spawn detection task
+        tokio::spawn(async move {
+            while let Ok(result) = chunk_rx.recv().await {
+                match result {
+                    Ok(chunk) => {
+                        let client = ctx
+                            .clients
+                            .get_as::<TextContentsDetectorClient>(&detector_id)
+                            .unwrap();
+                        match detect_text_contents(
+                            client,
+                            headers.clone(),
+                            detector_id.clone(),
+                            params.clone(),
+                            vec![chunk.clone()].into(),
+                        )
+                        .await
+                        {
+                            Ok(detections) => {
+                                // Send to detection channel
+                                let _ = detection_tx
+                                    .send(Ok((input_id, detector_id.clone(), chunk, detections)))
+                                    .await;
+                            }
+                            Err(error) => {
+                                // Send error to detection channel
+                                let _ = detection_tx.send(Err(error)).await;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        // Send error to detection channel
+                        let _ = detection_tx.send(Err(error)).await;
+                    }
+                }
+            }
+        });
+        let detection_stream = ReceiverStream::new(detection_rx).boxed();
+        streams.push(detection_stream);
+    }
+    Ok(streams)
+}
+
+/// Spawns text generation detection tasks.
+/// Returns a vec of detections.
+#[instrument(skip_all)]
+pub async fn text_generation_detections(
+    ctx: Arc<Context>,
+    headers: HeaderMap,
+    detectors: &HashMap<DetectorId, DetectorParams>,
+    input_id: InputId,
+    prompt: String,
+    generated_text: String,
+) -> Result<(InputId, Detections), Error> {
+    let inputs = detectors
+        .iter()
+        .map(|(detector_id, params)| {
+            Ok::<_, Error>((
+                detector_id.clone(),
+                params.clone(),
+                prompt.clone(),
+                generated_text.clone(),
+            ))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let results = stream::iter(inputs)
+        .map(|(detector_id, mut params, prompt, generated_text)| {
+            let ctx = ctx.clone();
+            let headers = headers.clone();
+            let threshold = params.pop_threshold().unwrap_or_default();
+            async move {
+                let client = ctx
+                    .clients
+                    .get_as::<TextGenerationDetectorClient>(&detector_id)
+                    .unwrap();
+                let detections = detect_text_generation(
+                    client,
+                    headers,
+                    detector_id.clone(),
+                    params,
+                    prompt,
+                    generated_text,
+                )
+                .await?
+                .into_iter()
+                .filter(|detection| detection.score >= threshold)
+                .map(|mut detection| {
+                    detection.detector_id = Some(detector_id.clone());
+                    detection
+                })
+                .collect::<Detections>();
+                Ok::<_, Error>(detections)
+            }
+        })
+        .buffer_unordered(8)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let detections = results.into_iter().flatten().collect::<Detections>();
+    Ok((input_id, detections))
+}
+
+/// Spawns text chat detection tasks.
+/// Returns a vec of detections.
+#[instrument(skip_all)]
+pub async fn text_chat_detections(
+    ctx: Arc<Context>,
+    headers: HeaderMap,
+    detectors: &HashMap<DetectorId, DetectorParams>,
+    input_id: InputId,
+    messages: Vec<openai::Message>,
+) -> Result<(InputId, Detections), Error> {
+    let inputs = detectors
+        .iter()
+        .map(|(detector_id, params)| {
+            Ok::<_, Error>((detector_id.clone(), params.clone(), messages.clone()))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let results = stream::iter(inputs)
+        .map(|(detector_id, mut params, messages)| {
+            let ctx = ctx.clone();
+            let headers = headers.clone();
+            let threshold = params.pop_threshold().unwrap_or_default();
+            async move {
+                let client = ctx
+                    .clients
+                    .get_as::<TextChatDetectorClient>(&detector_id)
+                    .unwrap();
+                let detections =
+                    detect_text_chat(client, headers, detector_id.clone(), params, messages)
+                        .await?
+                        .into_iter()
+                        .filter(|detection| detection.score >= threshold)
+                        .map(|mut detection| {
+                            detection.detector_id = Some(detector_id.clone());
+                            detection
+                        })
+                        .collect::<Detections>();
+                Ok::<_, Error>(detections)
+            }
+        })
+        .buffer_unordered(8)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let detections = results.into_iter().flatten().collect::<Detections>();
+    Ok((input_id, detections))
+}
+
+/// Spawns text context detection tasks.
+/// Returns a vec of detections.
+#[instrument(skip_all)]
+pub async fn text_context_detections(
+    ctx: Arc<Context>,
+    headers: HeaderMap,
+    detectors: &HashMap<DetectorId, DetectorParams>,
+    input_id: InputId,
+    content: String,
+    context_type: ContextType,
+    context: Vec<String>,
+) -> Result<(InputId, Detections), Error> {
+    let inputs = detectors
+        .iter()
+        .map(|(detector_id, params)| {
+            Ok::<_, Error>((
+                detector_id.clone(),
+                params.clone(),
+                content.clone(),
+                context_type.clone(),
+                context.clone(),
+            ))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let results = stream::iter(inputs)
+        .map(
+            |(detector_id, mut params, content, context_type, context)| {
+                let ctx = ctx.clone();
+                let headers = headers.clone();
+                let threshold = params.pop_threshold().unwrap_or_default();
+                async move {
+                    let client = ctx
+                        .clients
+                        .get_as::<TextContextDocDetectorClient>(&detector_id)
+                        .unwrap();
+                    let detections = detect_text_context(
+                        client,
+                        headers,
+                        detector_id.clone(),
+                        params,
+                        content,
+                        context_type,
+                        context,
+                    )
+                    .await?
+                    .into_iter()
+                    .filter(|detection| detection.score >= threshold)
+                    .map(|mut detection| {
+                        detection.detector_id = Some(detector_id.clone());
+                        detection
+                    })
+                    .collect::<Detections>();
+                    Ok::<_, Error>(detections)
+                }
+            },
+        )
+        .buffer_unordered(8)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let detections = results.into_iter().flatten().collect::<Detections>();
+    Ok((input_id, detections))
+}
+
+/// Fans-out a stream to a broadcast channel.
+pub fn broadcast_stream<T>(mut stream: BoxStream<T>) -> broadcast::Sender<T>
+where
+    T: Clone + Send + 'static,
+{
+    let (broadcast_tx, _) = broadcast::channel(32);
+    tokio::spawn({
+        let broadcast_tx = broadcast_tx.clone();
+        async move {
+            while let Some(msg) = stream.next().await {
+                let _ = broadcast_tx.send(msg);
+            }
+        }
+    });
+    broadcast_tx
+}

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -540,8 +540,8 @@ mod test {
             then.pb(TokenizationResults {
                 results: vec![
                     Token { start: 0, end: 57, text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit.".into() },
-                    Token { start: 58, end: 92, text: " Aenean commodo ligula eget dolor.".into() },
-                    Token { start: 93, end: 179, text: " Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.".into() }
+                    Token { start: 57, end: 92, text: " Aenean commodo ligula eget dolor.".into() },
+                    Token { start: 92, end: 179, text: " Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.".into() }
                 ],
                 token_count: 25,
             });
@@ -559,7 +559,7 @@ mod test {
                             .into(),
                     },
                     Token {
-                        start: 140,
+                        start: 139,
                         end: 201,
                         text: " Quo magni voluptatem et vitae maxime est voluptatem itaque. "
                             .into(),
@@ -676,7 +676,6 @@ mod test {
         fake_detector_server.start().await.unwrap();
 
         let mut config = OrchestratorConfig::default();
-        dbg!(&config);
         configure_mock_servers(
             &mut config,
             None,

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -698,7 +698,16 @@ mod test {
         Arc::new(Context::new(config, clients))
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    #[test_log::test(tokio::test)]
+    async fn tests() -> Result<(), Error> {
+        test_chunks().await?;
+        test_text_contents_detections().await?;
+        test_broadcast_stream().await?;
+        test_chunk_streams().await?;
+        test_text_contents_detection_streams().await?;
+        Ok(())
+    }
+
     async fn test_chunks() -> Result<(), Error> {
         let ctx = CONTEXT.get_or_init(init_context).await;
 
@@ -797,7 +806,6 @@ mod test {
         Ok(())
     }
 
-    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_text_contents_detections() -> Result<(), Error> {
         let ctx = CONTEXT.get_or_init(init_context).await;
 
@@ -849,7 +857,6 @@ mod test {
         Ok(())
     }
 
-    #[test_log::test(tokio::test)]
     async fn test_broadcast_stream() -> Result<(), Error> {
         let (tx, rx) = mpsc::channel(32);
         let stream = ReceiverStream::new(rx).boxed();
@@ -874,7 +881,6 @@ mod test {
         Ok(())
     }
 
-    #[test_log::test(tokio::test)]
     async fn test_chunk_streams() -> Result<(), Error> {
         let ctx = CONTEXT.get_or_init(init_context).await;
 
@@ -903,7 +909,7 @@ mod test {
             }
         });
 
-        let mut chunks = Vec::new();
+        let mut chunks = Vec::with_capacity(1);
         while let Ok(Ok(chunk)) = chunk_broadcast_rx.recv().await {
             chunks.push(chunk);
         }
@@ -923,7 +929,6 @@ mod test {
         Ok(())
     }
 
-    #[test_log::test(tokio::test)]
     async fn test_text_contents_detection_streams() -> Result<(), Error> {
         // TODO
         Ok(())

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -497,6 +497,7 @@ where
 
 #[cfg(test)]
 mod test {
+
     use mocktail::prelude::*;
     use tokio::sync::OnceCell;
 
@@ -675,6 +676,7 @@ mod test {
         fake_detector_server.start().await.unwrap();
 
         let mut config = OrchestratorConfig::default();
+        dbg!(&config);
         configure_mock_servers(
             &mut config,
             None,

--- a/src/orchestrator/common/utils.rs
+++ b/src/orchestrator/common/utils.rs
@@ -41,6 +41,7 @@ pub fn apply_masks(text: String, masks: Option<&[(usize, usize)]>) -> Vec<(usize
     }
 }
 
+/// Looks up chunker ids for detectors.
 pub fn get_chunker_ids(
     ctx: &Arc<Context>,
     detectors: &HashMap<String, DetectorParams>,

--- a/src/orchestrator/errors.rs
+++ b/src/orchestrator/errors.rs
@@ -29,8 +29,8 @@ pub enum Error {
     ChunkerRequestFailed { id: String, error: clients::Error },
     #[error("generate request failed for `{id}`: {error}")]
     GenerateRequestFailed { id: String, error: clients::Error },
-    #[error("chat generation request failed for `{id}`: {error}")]
-    ChatGenerateRequestFailed { id: String, error: clients::Error },
+    #[error("chat completion request failed for `{id}`: {error}")]
+    ChatCompletionRequestFailed { id: String, error: clients::Error },
     #[error("tokenize request failed for `{id}`: {error}")]
     TokenizeRequestFailed { id: String, error: clients::Error },
     #[error("validation error: {0}")]

--- a/src/orchestrator/errors.rs
+++ b/src/orchestrator/errors.rs
@@ -23,6 +23,8 @@ pub enum Error {
     Client(#[from] clients::Error),
     #[error("detector `{0}` not found")]
     DetectorNotFound(String),
+    #[error("chunker `{0}` not found")]
+    ChunkerNotFound(String),
     #[error("detector request failed for `{id}`: {error}")]
     DetectorRequestFailed { id: String, error: clients::Error },
     #[error("chunker request failed for `{id}`: {error}")]

--- a/src/orchestrator/types.rs
+++ b/src/orchestrator/types.rs
@@ -17,7 +17,6 @@
 use std::pin::Pin;
 
 use futures::Stream;
-use tokio::sync::mpsc;
 
 pub mod chat_message;
 pub use chat_message::*;
@@ -40,8 +39,6 @@ pub type InputId = u32;
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 pub type ChunkStream = BoxStream<Result<Chunk, Error>>;
 pub type InputStream = BoxStream<Result<(usize, String), Error>>;
-pub type InputSender = mpsc::Sender<Result<(usize, String), Error>>;
-pub type InputReceiver = mpsc::Receiver<Result<(usize, String), Error>>;
 pub type DetectionStream = BoxStream<Result<(InputId, DetectorId, Chunk, Detections), Error>>;
 pub type GenerationStream = BoxStream<(usize, Result<ClassifiedGeneratedTextStreamResult, Error>)>;
 pub type ChatCompletionStream = BoxStream<(usize, Result<Option<ChatCompletionChunk>, Error>)>;

--- a/src/server.rs
+++ b/src/server.rs
@@ -704,7 +704,7 @@ impl From<orchestrator::Error> for Error {
     fn from(value: orchestrator::Error) -> Self {
         use orchestrator::Error::*;
         match value {
-            DetectorNotFound(_) => Self::NotFound(value.to_string()),
+            DetectorNotFound(_) | ChunkerNotFound(_) => Self::NotFound(value.to_string()),
             DetectorRequestFailed { ref error, .. }
             | ChunkerRequestFailed { ref error, .. }
             | GenerateRequestFailed { ref error, .. }

--- a/src/server.rs
+++ b/src/server.rs
@@ -708,7 +708,7 @@ impl From<orchestrator::Error> for Error {
             DetectorRequestFailed { ref error, .. }
             | ChunkerRequestFailed { ref error, .. }
             | GenerateRequestFailed { ref error, .. }
-            | ChatGenerateRequestFailed { ref error, .. }
+            | ChatCompletionRequestFailed { ref error, .. }
             | TokenizeRequestFailed { ref error, .. } => match error.status_code() {
                 StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => {
                     Self::Validation(value.to_string())


### PR DESCRIPTION
## Changes:
- Adds 2 new modules for the refactor:
  - `common.tasks`: functionality reusable across task handlers
  - `common.clients`: client call helper functions
- Adds `configure_mock_servers()` to `common.utils` for unit tests
- Other changes:
  - Renames `Error::ChatGenerateRequestFailed` to `Error::ChatCompletionRequestFailed` (more accurate)
  - Adds `Error::ChunkerNotFound` variant
  - Adds `chunker()` and `detector()` convenience methods to `OrchestratorConfig`
  - Updates config types to implement `Default` always rather than just in a test cfg. The compiler was giving me problems using `configure_mock_servers()` without doing this. I don't see any issue with these types implementing `Default` anyways.

## Notes:
1. This includes an initial set of unit tests for the functions that will be used by the first 2 refactor PRs, planning to add more later
2. Due to issues experienced with unit test shared state created via `init_context()` + parallel test execution, I'm working around this by manually running the tests sequentially via a single `tests()` test function. This isn't ideal, but it works for now.
   - I attempted to use the [serial_test](https://github.com/palfrey/serial_test/) crate for this purpose, but it isn't working as expected. Some tests are running before the shared state, i.e. mock servers, are ready, resulting in errors such as below. I will open an issue there to try to understand why this is happening.
      ```
      Error::ChunkerRequestFailed { id: "sentence_chunker", error: Grpc { code: 500, message: "Service was not ready: transport error" } }
      ```