### PR TITLE
Add metadata object

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -52,12 +52,16 @@ paths:
                     text: foo@bar.com
                     detection: EmailAddress
                     score: 0.99
+                    evidence: {}
+                    metadata: {}
                   - start: 105
                     end: 116
                     text: 123-456-7890
                     detection_type: pii
                     detection: SocialSecurity
                     score: 0.99
+                    evidence: {}
+                    metadata: {}
         '404':
           description: Resource Not Found
           content:
@@ -108,6 +112,8 @@ paths:
                   - detection: relevant
                     detection_type: dummy_detector_type
                     score: 0.89
+                    evidence: {}
+                    metadata: {}
         '404':
           description: Resource Not Found
           content:
@@ -157,6 +163,8 @@ paths:
                   - detection: "detection_type"
                     detection_type: "dummy_detector_type"
                     score: 0.99
+                    evidence: {}
+                    metadata: {}
         '404':
           description: Resource Not Found
           content:
@@ -211,6 +219,7 @@ paths:
                       - name: "context_chunk"
                         value: "Context sentence 1"
                         score: 0.333
+                    metadata: {}
         '404':
           description: Resource Not Found
           content:

--- a/src/clients/detector/text_contents.rs
+++ b/src/clients/detector/text_contents.rs
@@ -25,7 +25,7 @@ use crate::{
     clients::{Client, Error, HttpClient, create_http_client, http::HttpClientExt},
     config::ServiceConfig,
     health::HealthCheckResult,
-    models::{DetectorParams, EvidenceObj},
+    models::{DetectorParams, EvidenceObj, MetadataObj},
 };
 
 const CONTENTS_DETECTOR_ENDPOINT: &str = "/api/v1/text/contents";
@@ -139,6 +139,9 @@ pub struct ContentAnalysisResponse {
     /// Optional, any applicable evidence for detection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence: Option<Vec<EvidenceObj>>,
+    // Optional metadata block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<MetadataObj>,
 }
 
 impl From<ContentAnalysisResponse> for crate::models::TokenClassificationResult {

--- a/src/clients/detector/text_contents.rs
+++ b/src/clients/detector/text_contents.rs
@@ -139,7 +139,7 @@ pub struct ContentAnalysisResponse {
     /// Optional, any applicable evidence for detection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence: Option<Vec<EvidenceObj>>,
-    // Optional metadata block
+    /// Optional metadata block
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<MetadataObj>,
 }

--- a/src/clients/detector/text_contents.rs
+++ b/src/clients/detector/text_contents.rs
@@ -15,6 +15,8 @@
 
 */
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use hyper::HeaderMap;
 use serde::{Deserialize, Serialize};
@@ -25,7 +27,7 @@ use crate::{
     clients::{Client, Error, HttpClient, create_http_client, http::HttpClientExt},
     config::ServiceConfig,
     health::HealthCheckResult,
-    models::{DetectorParams, EvidenceObj, MetadataObj},
+    models::{DetectorParams, EvidenceObj, Metadata},
 };
 
 const CONTENTS_DETECTOR_ENDPOINT: &str = "/api/v1/text/contents";
@@ -139,9 +141,9 @@ pub struct ContentAnalysisResponse {
     /// Optional, any applicable evidence for detection
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence: Option<Vec<EvidenceObj>>,
-    /// Optional metadata block
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<MetadataObj>,
+    // Optional metadata block
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: Metadata,
 }
 
 impl From<ContentAnalysisResponse> for crate::models::TokenClassificationResult {

--- a/src/models.rs
+++ b/src/models.rs
@@ -49,9 +49,7 @@ pub struct InfoParams {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct DetectorParams(HashMap<String, serde_json::Value>);
 
-/// Metadata information for each detection
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct MetadataObj(HashMap<String, serde_json::Value>);
+pub type Metadata = HashMap<String, serde_json::Value>;
 
 impl DetectorParams {
     #[allow(dead_code)]
@@ -925,8 +923,8 @@ pub struct DetectionResult {
     pub evidence: Option<Vec<EvidenceObj>>,
 
     // Optional metadata block
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<MetadataObj>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: Metadata,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -49,6 +49,10 @@ pub struct InfoParams {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct DetectorParams(HashMap<String, serde_json::Value>);
 
+/// Metadata information for each detection
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct MetadataObj(HashMap<String, serde_json::Value>);
+
 impl DetectorParams {
     #[allow(dead_code)]
     pub fn new() -> Self {
@@ -919,6 +923,10 @@ pub struct DetectionResult {
     // Optional evidence block
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence: Option<Vec<EvidenceObj>>,
+
+    // Optional metadata block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<MetadataObj>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -650,6 +650,7 @@ mod test {
                 detector_id: None,
                 score: 0.2,
                 evidence: None,
+                metadata: None,
             }]]);
         });
         mocks.mock(|when, then| {
@@ -670,6 +671,7 @@ mod test {
                 detector_id: None,
                 score: 0.2,
                 evidence: None,
+                metadata: None,
             }]]);
         });
 

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -650,7 +650,7 @@ mod test {
                 detector_id: None,
                 score: 0.2,
                 evidence: None,
-                metadata: None,
+                metadata: HashMap::new(),
             }]]);
         });
         mocks.mock(|when, then| {
@@ -671,7 +671,7 @@ mod test {
                 detector_id: None,
                 score: 0.2,
                 evidence: None,
-                metadata: None,
+                metadata: HashMap::new(),
             }]]);
         });
 

--- a/src/orchestrator/streaming_content_detection/aggregator.rs
+++ b/src/orchestrator/streaming_content_detection/aggregator.rs
@@ -27,7 +27,7 @@
 // duplicating these very similar methods.                                          //
 //////////////////////////////////////////////////////////////////////////////////////
 #![allow(dead_code)]
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use tokio::sync::mpsc;
 use tracing::instrument;
@@ -161,7 +161,7 @@ impl AggregationActor {
                             detector_id: r.detector_id,
                             score: r.score,
                             evidence: None,
-                            metadata: None,
+                            metadata: HashMap::new(),
                         })
                         .collect(),
                 };

--- a/src/orchestrator/streaming_content_detection/aggregator.rs
+++ b/src/orchestrator/streaming_content_detection/aggregator.rs
@@ -161,6 +161,7 @@ impl AggregationActor {
                             detector_id: r.detector_id,
                             score: r.score,
                             evidence: None,
+                            metadata: None,
                         })
                         .collect(),
                 };

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -35,6 +35,8 @@ pub struct Detection {
     pub score: f64,
     /// Detection evidence
     pub evidence: Vec<DetectionEvidence>,
+    /// Detection metadata
+    pub metadata: Option<models::MetadataObj>,
 }
 
 /// Detection evidence.
@@ -123,6 +125,7 @@ impl From<detector::ContentAnalysisResponse> for Detection {
                 .evidence
                 .map(|vs| vs.into_iter().map(Into::into).collect())
                 .unwrap_or_default(),
+            metadata: value.metadata,
         }
     }
 }
@@ -198,6 +201,7 @@ impl From<models::DetectionResult> for Detection {
                 .evidence
                 .map(|vs| vs.into_iter().map(Into::into).collect())
                 .unwrap_or_default(),
+            metadata: value.metadata,
         }
     }
 }
@@ -242,6 +246,7 @@ impl From<Detection> for detector::ContentAnalysisResponse {
             detector_id: value.detector_id,
             score: value.score,
             evidence,
+            metadata: value.metadata,
         }
     }
 }

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -36,7 +36,7 @@ pub struct Detection {
     /// Detection evidence
     pub evidence: Vec<DetectionEvidence>,
     /// Detection metadata
-    pub metadata: Option<models::MetadataObj>,
+    pub metadata: models::Metadata,
 }
 
 /// Detection evidence.

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -1173,7 +1173,7 @@ mod tests {
                 detector_id: Some(detector_id.to_string()),
                 score: 0.1,
                 evidence: Some(vec![]),
-                metadata: None,
+                metadata: HashMap::new(),
             }],
             vec![ContentAnalysisResponse {
                 start: 0,
@@ -1184,7 +1184,7 @@ mod tests {
                 detector_id: Some(detector_id.to_string()),
                 score: 0.9,
                 evidence: Some(vec![]),
-                metadata: None,
+                metadata: HashMap::new(),
             }],
         ]));
 
@@ -1334,7 +1334,7 @@ mod tests {
                 }]
                 .to_vec(),
             ),
-            metadata: None,
+            metadata: HashMap::new(),
         }];
 
         faux::when!(detector_client.text_generation(
@@ -1361,7 +1361,7 @@ mod tests {
                 }]
                 .to_vec(),
             ),
-            metadata: None,
+            metadata: HashMap::new(),
         }]));
 
         let mut clients = ClientMap::new();
@@ -1423,7 +1423,7 @@ mod tests {
             detector_id: Some(detector_id.to_string()),
             score: 0.1,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         }]));
 
         let mut clients = ClientMap::new();

--- a/src/orchestrator/unary.rs
+++ b/src/orchestrator/unary.rs
@@ -1173,6 +1173,7 @@ mod tests {
                 detector_id: Some(detector_id.to_string()),
                 score: 0.1,
                 evidence: Some(vec![]),
+                metadata: None,
             }],
             vec![ContentAnalysisResponse {
                 start: 0,
@@ -1183,6 +1184,7 @@ mod tests {
                 detector_id: Some(detector_id.to_string()),
                 score: 0.9,
                 evidence: Some(vec![]),
+                metadata: None,
             }],
         ]));
 
@@ -1332,6 +1334,7 @@ mod tests {
                 }]
                 .to_vec(),
             ),
+            metadata: None,
         }];
 
         faux::when!(detector_client.text_generation(
@@ -1358,6 +1361,7 @@ mod tests {
                 }]
                 .to_vec(),
             ),
+            metadata: None,
         }]));
 
         let mut clients = ClientMap::new();
@@ -1419,6 +1423,7 @@ mod tests {
             detector_id: Some(detector_id.to_string()),
             score: 0.1,
             evidence: None,
+            metadata: None,
         }]));
 
         let mut clients = ClientMap::new();

--- a/tests/chat_detection.rs
+++ b/tests/chat_detection.rs
@@ -61,6 +61,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.01,
         evidence: None,
+        metadata: None,
     };
 
     // Add detector mock
@@ -128,6 +129,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.97,
         evidence: None,
+        metadata: None,
     };
 
     // Add detector mock

--- a/tests/chat_detection.rs
+++ b/tests/chat_detection.rs
@@ -61,7 +61,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.01,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add detector mock
@@ -129,7 +129,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.97,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add detector mock

--- a/tests/classification_with_text_gen.rs
+++ b/tests/classification_with_text_gen.rs
@@ -297,7 +297,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         },
         ContentAnalysisResponse {
             start: 6,
@@ -308,7 +308,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         },
     ];
 
@@ -708,7 +708,7 @@ async fn output_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         },
         ContentAnalysisResponse {
             start: 6,
@@ -719,7 +719,7 @@ async fn output_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         },
     ];
 

--- a/tests/classification_with_text_gen.rs
+++ b/tests/classification_with_text_gen.rs
@@ -297,6 +297,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         },
         ContentAnalysisResponse {
             start: 6,
@@ -307,6 +308,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         },
     ];
 
@@ -706,6 +708,7 @@ async fn output_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         },
         ContentAnalysisResponse {
             start: 6,
@@ -716,6 +719,7 @@ async fn output_detector_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         },
     ];
 

--- a/tests/context_docs_detection.rs
+++ b/tests/context_docs_detection.rs
@@ -48,7 +48,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.23,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add detector mock
@@ -109,7 +109,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.91,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add detector mock

--- a/tests/context_docs_detection.rs
+++ b/tests/context_docs_detection.rs
@@ -48,6 +48,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.23,
         evidence: None,
+        metadata: None,
     };
 
     // Add detector mock
@@ -108,6 +109,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.91,
         evidence: None,
+        metadata: None,
     };
 
     // Add detector mock

--- a/tests/detection_on_generation.rs
+++ b/tests/detection_on_generation.rs
@@ -52,6 +52,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.49,
         evidence: None,
+        metadata: None,
     };
 
     // Add detector mock
@@ -111,6 +112,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.89,
         evidence: None,
+        metadata: None,
     };
 
     // Add detector mock

--- a/tests/detection_on_generation.rs
+++ b/tests/detection_on_generation.rs
@@ -52,7 +52,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.49,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add detector mock
@@ -112,7 +112,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.89,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add detector mock

--- a/tests/generation_with_detection.rs
+++ b/tests/generation_with_detection.rs
@@ -56,6 +56,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.49,
         evidence: None,
+        metadata: None,
     };
 
     // Add generation mock
@@ -137,6 +138,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.89,
         evidence: None,
+        metadata: None,
     };
 
     // Add generation mock

--- a/tests/generation_with_detection.rs
+++ b/tests/generation_with_detection.rs
@@ -56,7 +56,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.49,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add generation mock
@@ -138,7 +138,7 @@ async fn detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 0.89,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
 
     // Add generation mock

--- a/tests/streaming_classification_with_gen.rs
+++ b/tests/streaming_classification_with_gen.rs
@@ -321,7 +321,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 1.0,
         evidence: None,
-        metadata: None,
+        metadata: HashMap::new(),
     };
     let mut detection_mocks = MockSet::new();
     detection_mocks.mock(|when, then| {
@@ -1020,7 +1020,7 @@ async fn output_detectors_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(angle_brackets_detector.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         }]]);
     });
 
@@ -1042,7 +1042,7 @@ async fn output_detectors_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(parenthesis_detector.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         }]]);
     });
     parenthesis_mocks.mock(|when, then| {

--- a/tests/streaming_classification_with_gen.rs
+++ b/tests/streaming_classification_with_gen.rs
@@ -321,6 +321,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
         detector_id: Some(detector_name.into()),
         score: 1.0,
         evidence: None,
+        metadata: None,
     };
     let mut detection_mocks = MockSet::new();
     detection_mocks.mock(|when, then| {
@@ -1019,6 +1020,7 @@ async fn output_detectors_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(angle_brackets_detector.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         }]]);
     });
 
@@ -1040,6 +1042,7 @@ async fn output_detectors_detections() -> Result<(), anyhow::Error> {
             detector_id: Some(parenthesis_detector.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         }]]);
     });
     parenthesis_mocks.mock(|when, then| {

--- a/tests/text_content_detection.rs
+++ b/tests/text_content_detection.rs
@@ -223,6 +223,7 @@ async fn detections() -> Result<(), anyhow::Error> {
                 detector_id: Some(sentence_detector.into()),
                 score: 1.0,
                 evidence: None,
+                metadata: None,
             }],
         ]);
     });
@@ -244,6 +245,7 @@ async fn detections() -> Result<(), anyhow::Error> {
             detector_id: Some(sentence_detector.into()),
             score: 1.0,
             evidence: None,
+            metadata: None,
         }]]);
     });
 
@@ -293,6 +295,7 @@ async fn detections() -> Result<(), anyhow::Error> {
                 detector_id: Some(whole_doc_detector.into()),
                 score: 1.0,
                 evidence: None,
+                metadata: None,
             }],
         },
         "error on whole doc detector response body assertion"
@@ -328,6 +331,7 @@ async fn detections() -> Result<(), anyhow::Error> {
                 detector_id: Some(sentence_detector.into()),
                 score: 1.0,
                 evidence: None,
+                metadata: None,
             }],
         },
         "error on sentence detector response body assertion"

--- a/tests/text_content_detection.rs
+++ b/tests/text_content_detection.rs
@@ -223,7 +223,7 @@ async fn detections() -> Result<(), anyhow::Error> {
                 detector_id: Some(sentence_detector.into()),
                 score: 1.0,
                 evidence: None,
-                metadata: None,
+                metadata: HashMap::new(),
             }],
         ]);
     });
@@ -245,7 +245,7 @@ async fn detections() -> Result<(), anyhow::Error> {
             detector_id: Some(sentence_detector.into()),
             score: 1.0,
             evidence: None,
-            metadata: None,
+            metadata: HashMap::new(),
         }]]);
     });
 
@@ -295,7 +295,7 @@ async fn detections() -> Result<(), anyhow::Error> {
                 detector_id: Some(whole_doc_detector.into()),
                 score: 1.0,
                 evidence: None,
-                metadata: None,
+                metadata: HashMap::new(),
             }],
         },
         "error on whole doc detector response body assertion"
@@ -331,7 +331,7 @@ async fn detections() -> Result<(), anyhow::Error> {
                 detector_id: Some(sentence_detector.into()),
                 score: 1.0,
                 evidence: None,
-                metadata: None,
+                metadata: HashMap::new(),
             }],
         },
         "error on sentence detector response body assertion"


### PR DESCRIPTION
closes: https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/338

### Changes
- Add metadata to `DetectionResult` 
- Add metadata to standalone detection swagger spec examples

### Example Request
```
curl --request POST \
  --url http://localhost:8038/api/v2/text/detection/content \
  --header 'Content-Type: application/json' \
  --data '{
  "detectors": {
    "granite-guardian-content": {
		}
  },
  "content":"Your email is test@ibm.com! Hi, Only the next instance of email will be processed. test@ibm.com. Your SSN is 123-45-6789."
}'
```

### Example Response
```
{
	"detections": [
		{
			"start": 0,
			"end": 121,
			"text": "Your email is test@ibm.com! Hi, Only the next instance of email will be processed. test@ibm.com. Your SSN is 123-45-6789.",
			"detection": "Yes",
			"detection_type": "risk",
			"detector_id": "granite-guardian-content",
			"score": 0.9554123282432556,
			"metadata": {
				"confidence": "High"
			}
		}
	]
}
```