### PR TITLE
:construction_worker: Healthcheck command for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN groupadd --system orchestr8 --gid 1001 && \
 
 USER orchestr8
 
+HEALTHCHECK NONE
+
 ENV ORCHESTRATOR_CONFIG=/app/config/config.yaml
 
 CMD ["/app/bin/fms-guardrails-orchestr8"]


### PR DESCRIPTION
For `CIS_Docker_v1.5.0 - 4.6` compliance - generally we do not use docker for healthchecking