### PR TITLE
Fix DetectionBatchStream

### DIFF
--- a/src/orchestrator/types/detection_batch_stream.rs
+++ b/src/orchestrator/types/detection_batch_stream.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 /*
  Copyright FMS Guardrails Orchestrator Authors
 
@@ -15,9 +17,9 @@
 
 */
 use futures::{Stream, StreamExt, stream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
-use super::{DetectionBatcher, DetectionStream};
+use super::{Chunk, DetectionBatcher, DetectionStream, Detections, DetectorId, InputId};
 use crate::orchestrator::Error;
 
 /// A stream adapter that wraps multiple detection streams and
@@ -34,42 +36,45 @@ impl<B> DetectionBatchStream<B>
 where
     B: DetectionBatcher,
 {
-    pub fn new(mut batcher: B, streams: Vec<DetectionStream>) -> Self {
+    pub fn new(batcher: B, streams: Vec<DetectionStream>) -> Self {
         // Create batch channel
         let (batch_tx, batch_rx) = mpsc::channel(32);
-
         // Create a stream set (single stream) from multiple detection streams
         let mut stream_set = stream::select_all(streams);
+        // Create batcher manager
+        // This is an actor that manages batcher state rather than using locks.
+        let batcher_manager = DetectionBatcherManagerHandle::new(batcher);
 
-        // Spawn batcher task
-        // This task consumes new detections, pushes them to the batcher,
-        // and sends batches to the batch channel as they become ready.
+        // Spawn task to send batches as they become available
+        tokio::spawn({
+            let batch_tx = batch_tx.clone();
+            let batcher_manager = batcher_manager.clone();
+            async move {
+                loop {
+                    // Pop next batch, if ready
+                    if let Some(batch) = batcher_manager.pop().await {
+                        // Send batch to batch channel
+                        let _ = batch_tx.send(Ok(batch)).await;
+                    }
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+            }
+        });
+        // Spawn task to consume detections and send them to the batcher
         tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    result = stream_set.next() => {
-                        match result {
-                            Some(Ok((input_id, detector_id, chunk, detections))) => {
-                                // Push detections to batcher
-                                batcher.push(input_id, detector_id, chunk, detections);
-
-                                // Check if the next batch is ready
-                                if let Some(batch) = batcher.pop_batch() {
-                                    // Send batch to batch channel
-                                    let _ = batch_tx.send(Ok(batch)).await;
-                                }
-                            },
-                            Some(Err(error)) => {
-                                // Send error to batch channel
-                                let _ = batch_tx.send(Err(error)).await;
-                                break;
-                            },
-                            None => {
-                                // Detection stream set closed
-                                break;
-                            },
-                        }
-                    },
+            while let Some(result) = stream_set.next().await {
+                match result {
+                    Ok((input_id, detector_id, chunk, detections)) => {
+                        // Push detections
+                        batcher_manager
+                            .push(input_id, detector_id, chunk, detections)
+                            .await;
+                    }
+                    Err(error) => {
+                        // Send error to batch channel
+                        let _ = batch_tx.send(Err(error)).await;
+                        break;
+                    }
                 }
             }
         });
@@ -78,13 +83,108 @@ where
     }
 }
 
-impl<T: DetectionBatcher> Stream for DetectionBatchStream<T> {
-    type Item = Result<T::Batch, Error>;
+impl<B> Stream for DetectionBatchStream<B>
+where
+    B: DetectionBatcher,
+{
+    type Item = Result<B::Batch, Error>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         self.batch_rx.poll_recv(cx)
+    }
+}
+
+enum DetectionBatcherMessage<Batch> {
+    Push {
+        input_id: InputId,
+        detector_id: DetectorId,
+        chunk: Chunk,
+        detections: Detections,
+    },
+    Pop {
+        response_tx: oneshot::Sender<Option<Batch>>,
+    },
+}
+/// An actor that manages a [`DetectionBatcher`].
+struct DetectionBatcherManager<B: DetectionBatcher> {
+    batcher: B,
+    rx: mpsc::Receiver<DetectionBatcherMessage<B::Batch>>,
+}
+
+impl<B> DetectionBatcherManager<B>
+where
+    B: DetectionBatcher,
+{
+    pub fn new(batcher: B, rx: mpsc::Receiver<DetectionBatcherMessage<B::Batch>>) -> Self {
+        Self { batcher, rx }
+    }
+
+    async fn run(&mut self) {
+        while let Some(msg) = self.rx.recv().await {
+            match msg {
+                DetectionBatcherMessage::Push {
+                    input_id,
+                    detector_id,
+                    chunk,
+                    detections,
+                } => self.batcher.push(input_id, detector_id, chunk, detections),
+                DetectionBatcherMessage::Pop { response_tx } => {
+                    let batch = self.batcher.pop_batch();
+                    let _ = response_tx.send(batch);
+                }
+            }
+        }
+    }
+}
+
+/// A handle to a [`DetectionBatcherManager`].
+#[derive(Clone)]
+struct DetectionBatcherManagerHandle<B: DetectionBatcher> {
+    tx: mpsc::Sender<DetectionBatcherMessage<B::Batch>>,
+}
+
+impl<B> DetectionBatcherManagerHandle<B>
+where
+    B: DetectionBatcher,
+    B::Batch: Clone,
+{
+    /// Creates a new [`DetectionBatcherManager`] and returns it's handle.
+    pub fn new(batcher: B) -> Self {
+        let (tx, rx) = mpsc::channel(32);
+        let mut actor = DetectionBatcherManager::new(batcher, rx);
+        tokio::spawn(async move { actor.run().await });
+        Self { tx }
+    }
+
+    /// Pushes new detections to the batcher.
+    pub async fn push(
+        &self,
+        input_id: InputId,
+        detector_id: DetectorId,
+        chunk: Chunk,
+        detections: Detections,
+    ) {
+        let _ = self
+            .tx
+            .send(DetectionBatcherMessage::Push {
+                input_id,
+                detector_id,
+                chunk,
+                detections,
+            })
+            .await;
+    }
+
+    /// Removes the next batch of detections from the batcher, if ready.
+    pub async fn pop(&self) -> Option<B::Batch> {
+        let (response_tx, response_rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .send(DetectionBatcherMessage::Pop { response_tx })
+            .await;
+        response_rx.await.unwrap_or_default()
     }
 }

--- a/src/orchestrator/types/detection_batcher.rs
+++ b/src/orchestrator/types/detection_batcher.rs
@@ -25,8 +25,8 @@ use super::{Chunk, Detections, DetectorId, InputId};
 
 /// A detection batcher.
 /// Implements pluggable batching logic for a [`DetectionBatchStream`].
-pub trait DetectionBatcher: Clone + Send + 'static {
-    type Batch: Clone + Send + 'static;
+pub trait DetectionBatcher: std::fmt::Debug + Clone + Send + 'static {
+    type Batch: std::fmt::Debug + Clone + Send + 'static;
 
     /// Pushes new detections.
     fn push(
@@ -39,4 +39,7 @@ pub trait DetectionBatcher: Clone + Send + 'static {
 
     /// Removes the next batch of detections, if ready.
     fn pop_batch(&mut self) -> Option<Self::Batch>;
+
+    /// Returns `true` if the batcher state is empty.
+    fn is_empty(&self) -> bool;
 }

--- a/src/orchestrator/types/detection_batcher.rs
+++ b/src/orchestrator/types/detection_batcher.rs
@@ -25,8 +25,8 @@ use super::{Chunk, Detections, DetectorId, InputId};
 
 /// A detection batcher.
 /// Implements pluggable batching logic for a [`DetectionBatchStream`].
-pub trait DetectionBatcher: Send + 'static {
-    type Batch: Send + 'static;
+pub trait DetectionBatcher: Clone + Send + 'static {
+    type Batch: Clone + Send + 'static;
 
     /// Pushes new detections.
     fn push(

--- a/src/orchestrator/types/detection_batcher/chat_completion.rs
+++ b/src/orchestrator/types/detection_batcher/chat_completion.rs
@@ -15,27 +15,28 @@
 
 */
 #![allow(dead_code)]
+use std::collections::BTreeMap;
+
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
-use crate::orchestrator::types::Chunks;
 
 /// A batcher for chat completions.
+#[derive(Clone)]
 pub struct ChatCompletionBatcher {
     detectors: Vec<DetectorId>,
-    // state: TBD
+    state: BTreeMap<(Chunk, u32), Vec<Detections>>,
 }
 
 impl ChatCompletionBatcher {
     pub fn new(detectors: Vec<DetectorId>) -> Self {
-        // let state = TBD::new();
         Self {
             detectors,
-            // state,
+            state: BTreeMap::default(),
         }
     }
 }
 
 impl DetectionBatcher for ChatCompletionBatcher {
-    type Batch = (u32, Chunks, Detections); // placeholder, actual type TBD
+    type Batch = (u32, Chunk, Detections);
 
     fn push(
         &mut self,

--- a/src/orchestrator/types/detection_batcher/chat_completion.rs
+++ b/src/orchestrator/types/detection_batcher/chat_completion.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 
 /// A batcher for chat completions.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ChatCompletionBatcher {
     detectors: Vec<DetectorId>,
     state: BTreeMap<(Chunk, u32), Vec<Detections>>,
@@ -53,5 +53,9 @@ impl DetectionBatcher for ChatCompletionBatcher {
         // TODO: implement batching logic to align with requirements
         // ref: https://github.com/foundation-model-stack/fms-guardrails-orchestrator/blob/main/docs/architecture/adrs/005-chat-completion-support.md#streaming-response
         todo!()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.state.is_empty()
     }
 }

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -33,6 +33,7 @@ use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 /// and so on.
 ///
 /// This batcher requires that all detectors use the same chunker.
+#[derive(Clone)]
 pub struct MaxProcessedIndexBatcher {
     n_detectors: usize,
     state: BTreeMap<Chunk, Vec<Detections>>,

--- a/src/orchestrator/types/detection_batcher/max_processed_index.rs
+++ b/src/orchestrator/types/detection_batcher/max_processed_index.rs
@@ -33,7 +33,7 @@ use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 /// and so on.
 ///
 /// This batcher requires that all detectors use the same chunker.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MaxProcessedIndexBatcher {
     n_detectors: usize,
     state: BTreeMap<Chunk, Vec<Detections>>,
@@ -84,6 +84,10 @@ impl DetectionBatcher for MaxProcessedIndexBatcher {
             }
         }
         None
+    }
+
+    fn is_empty(&self) -> bool {
+        self.state.is_empty()
     }
 }
 

--- a/src/orchestrator/types/detection_batcher/noop.rs
+++ b/src/orchestrator/types/detection_batcher/noop.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 
 /// A no-op batcher that doesn't actually batch.
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct NoopBatcher {
     state: VecDeque<(Chunk, Detections)>,
 }
@@ -45,5 +45,9 @@ impl DetectionBatcher for NoopBatcher {
 
     fn pop_batch(&mut self) -> Option<Self::Batch> {
         self.state.pop_front()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.state.is_empty()
     }
 }

--- a/src/orchestrator/types/detection_batcher/noop.rs
+++ b/src/orchestrator/types/detection_batcher/noop.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use super::{Chunk, DetectionBatcher, Detections, DetectorId, InputId};
 
 /// A no-op batcher that doesn't actually batch.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct NoopBatcher {
     state: VecDeque<(Chunk, Detections)>,
 }


### PR DESCRIPTION
This PR refactors the `DetectionBatchStream` implementation to resolve the bug noted in #378. As part of the solution, a `DetectionBatcherManager` actor has been implemented to own and manage the batcher to avoid using locks as both push and pop operations require mutable borrows and pops are happening in a loop to get new batches as they become ready.

Notes: 
- I'm currently testing and comparing 2 slightly different implementations: (1) separate batcher and detection receiver tasks and (2) single task approach. This PR currently uses (2).
- Two small updates will need to be made to #380 for this:
  - Add `#[derive(Debug, Clone)]` to `ChatCompletionBatcher`
  - Add `is_empty()` to `impl DetectionBatcher for ChatCompletionBatcher`:
    ```rust
        fn is_empty(&self) -> bool {
            self.state.is_empty()
        }
    ```

Closes #378 