### PR TITLE
:goal_net: Handle unsupported media type errors

### DIFF
--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -25,7 +25,7 @@ use url::Url;
 
 use super::{
     Error,
-    http::{HttpClientExt, RequestBody, ResponseBody},
+    http::{HttpClientExt, JSON_CONTENT_TYPE, RequestBody, ResponseBody},
 };
 
 pub mod text_contents;
@@ -86,7 +86,7 @@ impl<C: DetectorClient + HttpClientExt> DetectorClientExt for C {
         request: impl RequestBody,
     ) -> Result<U, Error> {
         headers.append(DETECTOR_ID_HEADER_NAME, model_id.parse().unwrap());
-        headers.append(CONTENT_TYPE, "application/json".parse().unwrap());
+        headers.append(CONTENT_TYPE, JSON_CONTENT_TYPE);
         // Header used by a router component, if available
         headers.append(MODEL_HEADER_NAME, model_id.parse().unwrap());
 

--- a/src/clients/http.rs
+++ b/src/clients/http.rs
@@ -17,6 +17,7 @@
 
 use std::{fmt::Debug, ops::Deref, time::Duration};
 
+use http::header::HeaderValue;
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::{
     HeaderMap, Method, Request, StatusCode,
@@ -45,6 +46,8 @@ use crate::{
     health::{HealthCheckResult, HealthStatus, OptionalHealthCheckResponseBody},
     utils::{AsUriExt, trace},
 };
+
+pub const JSON_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/json");
 
 /// Any type that implements Debug and Serialize can be used as a request body
 pub trait RequestBody: Debug + Serialize {}

--- a/src/orchestrator/common/client.rs
+++ b/src/orchestrator/common/client.rs
@@ -30,6 +30,7 @@ use crate::{
             GenerationDetectionRequest, TextChatDetectorClient, TextContextDocDetectorClient,
             TextGenerationDetectorClient,
         },
+        http::JSON_CONTENT_TYPE,
         openai::{self, ChatCompletionsResponse, OpenAiClient},
     },
     models::{
@@ -251,7 +252,7 @@ pub async fn chat_completion(
 ) -> Result<openai::ChatCompletionsResponse, Error> {
     let model_id = request.model.clone();
     debug!(%model_id, ?request, "sending chat completions request");
-    headers.append(CONTENT_TYPE, "application/json".parse().unwrap());
+    headers.append(CONTENT_TYPE, JSON_CONTENT_TYPE);
     let response = client
         .chat_completions(request, headers)
         .await
@@ -272,7 +273,7 @@ pub async fn chat_completion_stream(
 ) -> Result<ChatCompletionStream, Error> {
     let model_id = request.model.clone();
     debug!(%model_id, ?request, "sending chat completions stream request");
-    headers.append(CONTENT_TYPE, "application/json".parse().unwrap());
+    headers.append(CONTENT_TYPE, JSON_CONTENT_TYPE);
     let response = client
         .chat_completions(request, headers)
         .await


### PR DESCRIPTION
Similar to #280 , I have observed `415`s on calling chat completions, resulting in 500s for the final completions-detection calls