### PR TITLE
Drop warning for empty choice content

### DIFF
--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -383,9 +383,6 @@ async fn process_chat_completion_stream(
                     if let Some(choice) = chat_completion.choices.first() {
                         // Extract choice text
                         let choice_text = choice.delta.content.clone().unwrap_or_default();
-                        if choice_text.is_empty() {
-                            warn!(%trace_id, %message_index, "chat completion chunk choice content is empty");
-                        }
                         // Update state for this choice index
                         if let Some(state) = &chat_completion_state {
                             match state.chat_completions.entry(choice.index) {


### PR DESCRIPTION
There are scenarios where this is valid, so this PR drops the warning log message when there is no choice content as this is fine.

e.g.
- The first message's choice only includes `role: assistant` with no content
- The final message with the stop reason may not include content
- Likely other scenarios