### PR TITLE
Test s390x build

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -30,11 +30,13 @@ COPY build.rs *.toml LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/
+# COPY tests/ /app/tests/
 
 WORKDIR /app
 
 # TODO: Make releases via cargo-release
 RUN cargo install --root /app/ --path .
+RUN cargo test
 
 ## Tests stage ##################################################################
 FROM fms-guardrails-orchestr8-builder AS tests

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -30,22 +30,13 @@ COPY build.rs *.toml LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/
-# COPY tests/ /app/tests/
+COPY tests/ /app/tests/
 
 WORKDIR /app
 
 # TODO: Make releases via cargo-release
 RUN cargo install --root /app/ --path .
 RUN cargo test
-
-## Tests stage ##################################################################
-FROM fms-guardrails-orchestr8-builder AS tests
-RUN cargo test
-
-## Lint stage ###################################################################
-FROM fms-guardrails-orchestr8-builder AS lint
-RUN cargo clippy --all-targets --all-features -- -D warnings
-
 ## Formatting check stage #######################################################
 FROM fms-guardrails-orchestr8-builder AS format
 RUN cargo +nightly fmt --check

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -35,18 +35,15 @@ COPY tests/ /app/tests/
 WORKDIR /app
 
 # TODO: Make releases via cargo-release
-RUN cargo install --root /app/ --path .
+RUN cargo build --release
 RUN cargo test
-## Formatting check stage #######################################################
-FROM fms-guardrails-orchestr8-builder AS format
-RUN cargo +nightly fmt --check
 
 ## Release Image ################################################################
 
 FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS fms-guardrails-orchestr8-release
 ARG CONFIG_FILE=config/config.yaml
 
-COPY --from=fms-guardrails-orchestr8-builder /app/bin/ /app/bin/
+COPY --from=fms-guardrails-orchestr8-builder /app/target/release/fms-guardrails-orchestr8 /app/bin/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 
 RUN microdnf install -y --disableplugin=subscription-manager shadow-utils compat-openssl11 && \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -31,15 +31,16 @@ COPY build.rs *.toml LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/
+COPY tests/ /app/tests/
 
 WORKDIR /app
 
 # TODO: Make releases via cargo-release
 RUN cargo install --root /app/ --path .
+RUN cargo test
 
 ## Tests stage ##################################################################
 FROM fms-guardrails-orchestr8-builder AS tests
-RUN cargo test
 
 ## Lint stage ###################################################################
 FROM fms-guardrails-orchestr8-builder AS lint

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -39,17 +39,6 @@ WORKDIR /app
 RUN cargo install --root /app/ --path .
 RUN cargo test
 
-## Tests stage ##################################################################
-FROM fms-guardrails-orchestr8-builder AS tests
-
-## Lint stage ###################################################################
-FROM fms-guardrails-orchestr8-builder AS lint
-RUN cargo clippy --all-targets --all-features -- -D warnings
-
-## Formatting check stage #######################################################
-FROM fms-guardrails-orchestr8-builder AS format
-RUN cargo +nightly fmt --check
-
 ## Release Image ################################################################
 
 FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS fms-guardrails-orchestr8-release

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -36,7 +36,7 @@ COPY tests/ /app/tests/
 WORKDIR /app
 
 # TODO: Make releases via cargo-release
-RUN cargo install --root /app/ --path .
+RUN cargo build --release
 RUN cargo test
 
 ## Release Image ################################################################
@@ -44,7 +44,7 @@ RUN cargo test
 FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS fms-guardrails-orchestr8-release
 ARG CONFIG_FILE=config/config.yaml
 
-COPY --from=fms-guardrails-orchestr8-builder /app/bin/ /app/bin/
+COPY --from=fms-guardrails-orchestr8-builder /app/target/release/fms-guardrails-orchestr8 /app/bin/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 
 RUN microdnf install -y --disableplugin=subscription-manager shadow-utils compat-openssl11 && \


### PR DESCRIPTION
Closes #422.

Summary:
1. Removed linting and formatting steps.
2. Moved testing to previous stage and copied `tests` folder content.
3. Replaced `cargo install` with `cargo build --release` to create the orchestrator binary.