### PR TITLE
fix: only send non-empty choice text to detection input channel

### DIFF
--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -403,7 +403,9 @@ async fn process_chat_completion_stream(
                         if let Some(input_tx) =
                             input_txs.as_ref().and_then(|txs| txs.get(&choice.index))
                         {
-                            let _ = input_tx.send(Ok((message_index, choice_text))).await;
+                            if !choice_text.is_empty() {
+                                let _ = input_tx.send(Ok((message_index, choice_text))).await;
+                            }
                         }
                     } else {
                         debug!(%trace_id, %message_index, ?chat_completion, "chat completion chunk contains no choice");


### PR DESCRIPTION
This PR fixes an issue where non-empty choice text was being sent to the detection input channel