### PR TITLE
:bug: Update OpenAI openAPI spec location

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -867,7 +867,7 @@ components:
       title: Guardrails Chat Completion Request
       description: Guardrails chat completion request (adds detectors on OpenAI chat completion)
       allOf:
-        - $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/CreateChatCompletionRequest
+        - $ref: https://raw.githubusercontent.com/openai/openai-openapi/manual_spec/openapi.yaml#/components/schemas/CreateChatCompletionRequest
         - type: object
       properties:
         detectors:
@@ -880,7 +880,7 @@ components:
       title: Guardrails Chat Completion Response
       description: Guardrails chat completion response (adds detections on OpenAI chat completion)
       allOf:
-        - $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/CreateChatCompletionResponse
+        - $ref: https://raw.githubusercontent.com/openai/openai-openapi/manual_spec/openapi.yaml#/components/schemas/CreateChatCompletionResponse
         - type: object
       properties:
         detections:


### PR DESCRIPTION
2 weeks ago the API spec for OpenAI OpenAPI was moved - https://github.com/openai/openai-openapi?tab=readme-ov-file

This led to some errors on our API generation since we use those objects directly - this updates the links