### PR TITLE
:bug: Update OpenAI openAPI spec location for standalone chat

### DIFF
--- a/docs/api/openapi_detector_api.yaml
+++ b/docs/api/openapi_detector_api.yaml
@@ -250,7 +250,7 @@ components:
           type: array
           items:
             allOf:
-              - $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionRequestMessage
+              - $ref: https://raw.githubusercontent.com/openai/openai-openapi/manual_spec/openapi.yaml#/components/schemas/ChatCompletionRequestMessage
               - type: object
         tools:
           type: array
@@ -260,7 +260,7 @@ components:
             the model may generate JSON inputs for. A max of 128 functions
             are supported.
           items:
-            $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionTool
+            $ref: https://raw.githubusercontent.com/openai/openai-openapi/manual_spec/openapi.yaml#/components/schemas/ChatCompletionTool
         detector_params:
           type: object
           default: {}

--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -505,7 +505,7 @@ components:
           minItems: 1
           items:
             allOf:
-              - $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionRequestMessage
+              - $ref: https://raw.githubusercontent.com/openai/openai-openapi/manual_spec/openapi.yaml#/components/schemas/ChatCompletionRequestMessage
               - type: object
         tools:
           type: array
@@ -515,7 +515,7 @@ components:
             the model may generate JSON inputs for. A max of 128 functions
             are supported.
           items:
-            $ref: https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml#/components/schemas/ChatCompletionTool
+            $ref: https://raw.githubusercontent.com/openai/openai-openapi/manual_spec/openapi.yaml#/components/schemas/ChatCompletionTool
       additionalProperties: false
       required: ["detectors", "messages"]
       type: object


### PR DESCRIPTION
Addendum to #433 for the standalone chat detection and relevant detectors API endpoint