### PR TITLE
:memo::sparkles: API update to support detections on vLLM `/completions`

### DIFF
--- a/docs/api/orchestrator_openapi_0_1_0.yaml
+++ b/docs/api/orchestrator_openapi_0_1_0.yaml
@@ -977,7 +977,7 @@ components:
                   "text": "string",
                   "detection_type": "HAP",
                   "detection": "has_HAP",
-                  "detector_id": "hap-v1-model-en", # Future addition
+                  "detector_id": "hap-v1-model-en",
                   "score": 0.999,
                 }
         output:
@@ -990,16 +990,15 @@ components:
                   "text": "string",
                   "detection_type": "HAP",
                   "detection": "has_HAP",
-                  "detector_id": "hap-v1-model-en", # Future addition
+                  "detector_id": "hap-v1-model-en",
                   "score": 0.999,
                 }
               - {
                   "detection_type": "string",
                   "detection": "string",
-                  "detector_id": "relevance-v1-en", # Future addition
+                  "detector_id": "relevance-v1-en",
                   "score": 0,
                 }
-
     MessageDetections:
       title: Message Detections
       properties:
@@ -1018,24 +1017,6 @@ components:
               - $ref: "#/components/schemas/GeneratedTextDetectionResponseObject"
       required:
         - message_index
-    ChoiceDetections:
-      title: Choice Detections
-      properties:
-        choice_index:
-          oneOf:
-            - type: string # "all"
-            - type: integer # index
-          title: Index of choice
-        results:
-          title: Detection results
-          type: array
-          items:
-            anyOf:
-              - $ref: "#/components/schemas/DetectionContentResponseObject"
-              - $ref: "#/components/schemas/DetectionContextDocsResponseObject"
-              - $ref: "#/components/schemas/GeneratedTextDetectionResponseObject"
-      required:
-        - choice_index
 
     ########################## Completion #################################
     GuardrailsCreateCompletionRequest:
@@ -1059,8 +1040,7 @@ components:
         - type: object
       properties:
         detections:
-          # TODO: EDIT
-          $ref: "#/components/schemas/ChatCompletionsDetections"
+          $ref: "#/components/schemas/CompletionsDetections"
         warnings:
           type: array
           items:
@@ -1068,7 +1048,82 @@ components:
       required:
         - detections
 
+    CompletionsDetections:
+      title: Completions Detections
+      properties:
+        input:
+          type: array
+          items:
+            $ref: "#/components/schemas/PromptDetections"
+          title: Detections on prompt for completions
+          default: {}
+        output:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChoiceDetections"
+          title: Detections on output of completions
+          default: {}
+      default: {}
+      example:
+        input:
+          - results:
+              - {
+                  "start": 0,
+                  "end": 80,
+                  "text": "string",
+                  "detection_type": "HAP",
+                  "detection": "has_HAP",
+                  "detector_id": "hap-v1-model-en",
+                  "score": 0.999,
+                }
+        output:
+          - choice_index: 0
+          - choice_index: 1
+            results:
+              - {
+                  "start": 0,
+                  "end": 20,
+                  "text": "string",
+                  "detection_type": "HAP",
+                  "detection": "has_HAP",
+                  "detector_id": "hap-v1-model-en",
+                  "score": 0.999,
+                }
+              - {
+                  "detection_type": "string",
+                  "detection": "string",
+                  "detector_id": "relevance-v1-en",
+                  "score": 0,
+                }
+    PromptDetections:
+      title: Prompt Detections
+      properties:
+        results:
+          title: Detection results
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/DetectionContentResponseObject"
+
     ########################## General #################################
+    ChoiceDetections:
+      title: Choice Detections
+      properties:
+        choice_index:
+          oneOf:
+            - type: string # "all"
+            - type: integer # index
+          title: Index of choice
+        results:
+          title: Detection results
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/DetectionContentResponseObject"
+              - $ref: "#/components/schemas/DetectionContextDocsResponseObject"
+              - $ref: "#/components/schemas/GeneratedTextDetectionResponseObject"
+      required:
+        - choice_index
     Detectors:
       title: Guardrails Detectors
       description: Specify detectors for guardrails


### PR DESCRIPTION
Similar to the current `/v2/chat/completions-detection` which adds detectors on the request and detections to the response of vLLM (extending openAI's) `/chat/completions`, this endpoint `/v2/text/completions-detection` adds detectors on the request and detections to the response of vLLM (extending openAI's) legacy [`/completions` endpoint](https://platform.openai.com/docs/api-reference/completions). While "legacy" and not receiving updates, this is not deprecated and is still useful for general text generation use cases, and more popular than the current TGIS API and caikit API support.

Note: The `prompt` for `/completions` can be a string, or array of strings, or token integers etc. Complete detection support for all types may not be added immediately on implementation. Currently prompt detections are like output choice detections or chat-completions input detections, but without `message_index` or `choice_index`. The `results` key and nested structure is kept for consistency and could allow for extension of `index` info in the future such as for array support.

Other API updates:
- `400` is now returned in some cases, such as when bad requests to vLLM are sent (and the result is propagated back to the user)
- `detector_id` support was added in #203 so the comments can be removed
- Some common schemas between chat-completions and completions were moved to the "general" section

Part of #348 