### PR TITLE
Rename `chat_completions` config to `openai`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,7 +12,7 @@ generation:
         hostname: localhost
         port: 8033
 # Generation server used for chat endpoints
-# chat_completions:
+# openai:
 #   service:
 #     hostname: localhost
 #     port: 8080

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,6 +196,7 @@ pub struct OrchestratorConfig {
     pub generation: Option<GenerationConfig>,
     /// Open AI service and associated configuration, can be omitted if configuring for chat generation is not wanted
     #[serde(alias = "chat_generation")]
+    #[serde(alias = "chat_completions")]
     pub openai: Option<OpenAiConfig>,
     /// Chunker services and associated configurations, if omitted the default value "whole_doc_chunker" is used
     pub chunkers: Option<HashMap<String, ChunkerConfig>>,
@@ -225,9 +226,15 @@ impl OrchestratorConfig {
                 error,
             }
         })?;
+        // TODO: Remove if conditions once aliases are deprecated
         if config_yaml.contains("chat_generation") {
             warn!(
                 "`chat_generation` is deprecated and will be removed in 1.0. Rename it to `openai`."
+            )
+        }
+        if config_yaml.contains("chat_completions") {
+            warn!(
+                "`chat_completions` is deprecated and will be removed in 1.0. Rename it to `openai`."
             )
         }
         let mut config: OrchestratorConfig =

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,7 +194,7 @@ pub enum DetectorType {
 pub struct OrchestratorConfig {
     /// Generation service and associated configuration, can be omitted if configuring for generation is not wanted
     pub generation: Option<GenerationConfig>,
-    /// Open AI service and associated configuration, can be omitted if configuring for chat generation is not wanted
+    /// OpenAI service and associated configuration, can be omitted if configuring for chat generation is not wanted
     #[serde(alias = "chat_generation")]
     #[serde(alias = "chat_completions")]
     pub openai: Option<OpenAiConfig>,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -141,13 +141,10 @@ async fn create_clients(config: &OrchestratorConfig) -> Result<ClientMap, Error>
     }
 
     // Create chat completions client
-    if let Some(chat_completions) = &config.chat_completions {
-        let openai_client = OpenAiClient::new(
-            &chat_completions.service,
-            chat_completions.health_service.as_ref(),
-        )
-        .await?;
-        clients.insert("chat_completions".to_string(), openai_client);
+    if let Some(openai) = &config.openai {
+        let openai_client =
+            OpenAiClient::new(&openai.service, openai.health_service.as_ref()).await?;
+        clients.insert("openai".to_string(), openai_client);
     }
 
     // Create chunker clients

--- a/src/orchestrator/common/utils.rs
+++ b/src/orchestrator/common/utils.rs
@@ -75,7 +75,7 @@ pub fn current_timestamp() -> std::time::Duration {
 pub fn configure_mock_servers(
     config: &mut crate::config::OrchestratorConfig,
     generation_server: Option<&mocktail::server::MockServer>,
-    chat_completions_server: Option<&mocktail::server::MockServer>,
+    openai_server: Option<&mocktail::server::MockServer>,
     detector_servers: Option<Vec<&mocktail::server::MockServer>>,
     chunker_servers: Option<Vec<&mocktail::server::MockServer>>,
 ) {
@@ -85,11 +85,11 @@ pub fn configure_mock_servers(
         generation_config.service.port = Some(server.addr().unwrap().port());
         config.generation = Some(generation_config);
     }
-    if let Some(server) = chat_completions_server {
-        let mut chat_completions_config = crate::config::OpenAiConfig::default();
-        chat_completions_config.service.hostname = "localhost".into();
-        chat_completions_config.service.port = Some(server.addr().unwrap().port());
-        config.chat_completions = Some(chat_completions_config);
+    if let Some(server) = openai_server {
+        let mut openai_config = crate::config::OpenAiConfig::default();
+        openai_config.service.hostname = "localhost".into();
+        openai_config.service.port = Some(server.addr().unwrap().port());
+        config.openai = Some(openai_config);
     };
     if let Some(servers) = detector_servers {
         for server in servers {

--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -111,7 +111,7 @@ pub async fn handle_streaming(
             // Create chat completions stream
             let client = ctx
                 .clients
-                .get_as::<OpenAiClient>("chat_completions")
+                .get_as::<OpenAiClient>("openai")
                 .unwrap();
             let chat_completion_stream = match common::chat_completion_stream(client, task.headers.clone(), task.request.clone()).await {
                 Ok(stream) => stream,

--- a/src/orchestrator/handlers/chat_completions_detection/unary.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/unary.rs
@@ -76,10 +76,7 @@ pub async fn handle_unary(
     }
 
     // Handle chat completion
-    let client = ctx
-        .clients
-        .get_as::<OpenAiClient>("chat_completions")
-        .unwrap();
+    let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
     let chat_completion =
         match common::chat_completion(client, task.headers.clone(), task.request.clone()).await {
             Ok(ChatCompletionsResponse::Unary(chat_completion)) => *chat_completion,

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -89,7 +89,7 @@ pub fn guardrails_router(state: Arc<ServerState>) -> Router {
             post(detect_context_documents),
         )
         .route("/api/v2/text/detection/generated", post(detect_generated));
-    if state.orchestrator.config().chat_completions.is_some() {
+    if state.orchestrator.config().openai.is_some() {
         info!("Enabling chat completions detection endpoint");
         router = router.route(
             "/api/v2/chat/completions-detection",

--- a/tests/chat_completions_detection.rs
+++ b/tests/chat_completions_detection.rs
@@ -124,12 +124,11 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mut mock_chat_completions_server =
-        MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mut mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
-        .chat_completions_server(&mock_chat_completions_server)
+        .openai_server(&mock_openai_server)
         .build()
         .await?;
 
@@ -223,7 +222,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     ];
 
     // add new mock
-    mock_chat_completions_server.mock(|when, then| {
+    mock_openai_server.mock(|when, then| {
         when.post().path(CHAT_COMPLETIONS_ENDPOINT).json(json!({
             "model": MODEL_ID,
             "messages": messages,
@@ -344,12 +343,12 @@ async fn no_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_chat_completions_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
-        .chat_completions_server(&mock_chat_completions_server)
+        .openai_server(&mock_openai_server)
         .build()
         .await?;
 
@@ -430,7 +429,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         ..Default::default()
     };
 
-    mock_chat_completions_server.mocks().mock(|when, then| {
+    mock_openai_server.mocks().mock(|when, then| {
         when.post().path(CHAT_COMPLETIONS_ENDPOINT).json(json!({
             "model": MODEL_ID,
             "messages": messages,
@@ -549,7 +548,7 @@ async fn input_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_chat_completions_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -558,7 +557,7 @@ async fn input_detections() -> Result<(), anyhow::Error> {
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
         .chunker_servers([&mock_chunker_server])
-        .chat_completions_server(&mock_chat_completions_server)
+        .openai_server(&mock_openai_server)
         .build()
         .await?;
 
@@ -708,7 +707,7 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_chat_completions_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -717,7 +716,7 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
         .chunker_servers([&mock_chunker_server])
-        .chat_completions_server(&mock_chat_completions_server)
+        .openai_server(&mock_openai_server)
         .build()
         .await?;
 
@@ -935,7 +934,7 @@ async fn output_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_chat_completions_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -944,7 +943,7 @@ async fn output_detections() -> Result<(), anyhow::Error> {
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
         .chunker_servers([&mock_chunker_server])
-        .chat_completions_server(&mock_chat_completions_server)
+        .openai_server(&mock_openai_server)
         .build()
         .await?;
 
@@ -1113,7 +1112,7 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_chat_completions_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -1122,7 +1121,7 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
         .chunker_servers([&mock_chunker_server])
-        .chat_completions_server(&mock_chat_completions_server)
+        .openai_server(&mock_openai_server)
         .build()
         .await?;
 

--- a/tests/chat_completions_detection.rs
+++ b/tests/chat_completions_detection.rs
@@ -124,7 +124,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mut mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mut mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -343,7 +343,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -548,7 +548,7 @@ async fn input_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -707,7 +707,7 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -934,7 +934,7 @@ async fn output_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);
@@ -1112,7 +1112,7 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("chat_completions").with_mocks(chat_mocks);
+    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
         .grpc()
         .with_mocks(chunker_mocks);

--- a/tests/common/orchestrator.rs
+++ b/tests/common/orchestrator.rs
@@ -72,7 +72,7 @@ pub struct TestOrchestratorServerBuilder<'a> {
     port: Option<u16>,
     health_port: Option<u16>,
     generation_server: Option<&'a MockServer>,
-    chat_completions_server: Option<&'a MockServer>,
+    openai_server: Option<&'a MockServer>,
     detector_servers: Option<Vec<&'a MockServer>>,
     chunker_servers: Option<Vec<&'a MockServer>>,
 }
@@ -102,8 +102,8 @@ impl<'a> TestOrchestratorServerBuilder<'a> {
         self
     }
 
-    pub fn chat_completions_server(mut self, server: &'a MockServer) -> Self {
-        self.chat_completions_server = Some(server);
+    pub fn openai_server(mut self, server: &'a MockServer) -> Self {
+        self.openai_server = Some(server);
         self
     }
 
@@ -126,7 +126,7 @@ impl<'a> TestOrchestratorServerBuilder<'a> {
 
         // Start & configure mock servers
         initialize_generation_server(self.generation_server, &mut config).await?;
-        initialize_chat_completions_server(self.chat_completions_server, &mut config).await?;
+        initialize_openai_server(self.openai_server, &mut config).await?;
         initialize_detectors(self.detector_servers.as_deref(), &mut config).await?;
         initialize_chunkers(self.chunker_servers.as_deref(), &mut config).await?;
 
@@ -214,14 +214,13 @@ async fn initialize_generation_server(
 }
 
 /// Starts and configures chat generation server.
-async fn initialize_chat_completions_server(
-    chat_completions_server: Option<&MockServer>,
+async fn initialize_openai_server(
+    openai_server: Option<&MockServer>,
     config: &mut OrchestratorConfig,
 ) -> Result<(), anyhow::Error> {
-    if let Some(chat_completions_server) = chat_completions_server {
-        chat_completions_server.start().await?;
-        config.chat_completions.as_mut().unwrap().service.port =
-            Some(chat_completions_server.addr().unwrap().port());
+    if let Some(openai_server) = openai_server {
+        openai_server.start().await?;
+        config.openai.as_mut().unwrap().service.port = Some(openai_server.addr().unwrap().port());
     };
     Ok(())
 }


### PR DESCRIPTION
With the upcoming work to support Open AI's completions endpoint, we should rename the orchestrator config file entry to `openai`, as it will be used for other endpoints rather than just chat completions.