### PR TITLE
Upgrade mocktail to 0.3.0, update tests to use new MockServer constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1433,8 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "mocktail"
-version = "0.2.5-alpha"
-source = "git+https://github.com/IBM/mocktail#025d724965f5d4ee7cc6666bf22845a896b00b58"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053f7ba52863e22dfd2970075bbc69c4224ca6ae03896a5f69a0d5982deb5e0a"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ dashmap = "6.1.0"
 eventsource-stream = "0.2.3"
 futures = "0.3.31"
 futures-util = { version = "0.3", default-features = false, features = [] }
-ginepro = {git = "https://github.com/gkumbhat/ginepro", rev = "863ca186f37abf5997126aa97e85b56ca288a76c"}
+ginepro = { git = "https://github.com/gkumbhat/ginepro", rev = "863ca186f37abf5997126aa97e85b56ca288a76c" }
 http = "1.3.1"
 http-body = "1.0"
 http-body-util = "0.1.3"
@@ -91,7 +91,7 @@ tonic-build = "0.13.1"
 
 [dev-dependencies]
 axum-test = "17.3.0"
-mocktail = { git = "https://github.com/IBM/mocktail" }
+mocktail = "0.3.0"
 rand = "0.9.1"
 test-log = "0.2.18"
 

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -611,7 +611,7 @@ mod test {
                 input_end_index: 2,
             }]);
         });
-        let sentence_chunker_server = MockServer::new("sentence_chunker").grpc().with_mocks(mocks);
+        let sentence_chunker_server = MockServer::new_grpc("sentence_chunker").with_mocks(mocks);
         sentence_chunker_server.start().await.unwrap();
 
         // Create whole_doc_chunker
@@ -628,9 +628,7 @@ mod test {
                 token_count: 25,
             });
         });
-        let whole_doc_chunker_server = MockServer::new("whole_doc_chunker")
-            .grpc()
-            .with_mocks(mocks);
+        let whole_doc_chunker_server = MockServer::new_grpc("whole_doc_chunker").with_mocks(mocks);
         whole_doc_chunker_server.start().await.unwrap();
 
         // Create error chunker
@@ -639,7 +637,7 @@ mod test {
             when.path(CHUNKER_PATH);
             then.internal_server_error();
         });
-        let error_chunker_server = MockServer::new("error_chunker").grpc().with_mocks(mocks);
+        let error_chunker_server = MockServer::new_grpc("error_chunker").with_mocks(mocks);
         error_chunker_server.start().await.unwrap();
 
         // Create fake detector

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -687,7 +687,7 @@ mod test {
             }]]);
         });
 
-        let fake_detector_server = MockServer::new("fake_detector").with_mocks(mocks);
+        let fake_detector_server = MockServer::new_http("fake_detector").with_mocks(mocks);
         fake_detector_server.start().await.unwrap();
 
         let mut config = OrchestratorConfig::default();

--- a/tests/chat_completions_streaming.rs
+++ b/tests/chat_completions_streaming.rs
@@ -334,7 +334,7 @@ async fn no_detectors_n2() -> Result<(), anyhow::Error> {
 async fn input_detectors() -> Result<(), anyhow::Error> {
     let openai_server = MockServer::new("openai");
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_UNARY_ENDPOINT)
@@ -628,7 +628,7 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_STREAMING_ENDPOINT)
@@ -1201,7 +1201,7 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_STREAMING_ENDPOINT)
@@ -1771,7 +1771,7 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_STREAMING_ENDPOINT)
@@ -2431,7 +2431,7 @@ async fn output_detectors_n2() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     // choice 0 mocks
     sentence_chunker_server.mock(|when, then| {
         when.post()
@@ -3333,7 +3333,7 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_STREAMING_ENDPOINT)
@@ -4020,7 +4020,7 @@ async fn chunker_internal_server_error() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_STREAMING_ENDPOINT)
@@ -4310,7 +4310,7 @@ async fn detector_internal_server_error() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut sentence_chunker_server = MockServer::new("sentence_chunker").grpc();
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
         when.post()
             .path(CHUNKER_STREAMING_ENDPOINT)

--- a/tests/chat_completions_streaming.rs
+++ b/tests/chat_completions_streaming.rs
@@ -32,7 +32,7 @@ use crate::common::{
 
 #[test(tokio::test)]
 async fn no_detectors() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when
         .post()
@@ -149,7 +149,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn no_detectors_n2() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -332,7 +332,7 @@ async fn no_detectors_n2() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn input_detectors() -> Result<(), anyhow::Error> {
-    let openai_server = MockServer::new("openai");
+    let openai_server = MockServer::new_http("openai");
 
     let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
     sentence_chunker_server.mock(|when, then| {
@@ -349,7 +349,7 @@ async fn input_detectors() -> Result<(), anyhow::Error> {
         });
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -435,7 +435,7 @@ async fn input_detectors() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn output_detectors() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -715,7 +715,7 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
         ]);
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -917,7 +917,7 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -1288,7 +1288,7 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
         ]);
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -1562,7 +1562,7 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -1858,7 +1858,7 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
         ]);
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -2075,7 +2075,7 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn output_detectors_n2() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -2601,7 +2601,7 @@ async fn output_detectors_n2() -> Result<(), anyhow::Error> {
         ]);
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     // choice 0 mocks
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
@@ -2832,7 +2832,7 @@ async fn output_detectors_n2() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn whole_doc_output_detectors() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -3025,7 +3025,7 @@ async fn whole_doc_output_detectors() -> Result<(), anyhow::Error> {
         ]));
     });
 
-    let mut pii_detector_whole_doc_server = MockServer::new("pii_detector_whole_doc");
+    let mut pii_detector_whole_doc_server = MockServer::new_http("pii_detector_whole_doc");
     pii_detector_whole_doc_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -3140,7 +3140,7 @@ async fn whole_doc_output_detectors() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -3420,7 +3420,7 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
         ]);
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -3474,7 +3474,7 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
         ]]));
     });
 
-    let mut pii_detector_whole_doc_server = MockServer::new("pii_detector_whole_doc");
+    let mut pii_detector_whole_doc_server = MockServer::new_http("pii_detector_whole_doc");
     pii_detector_whole_doc_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
@@ -3696,7 +3696,7 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
 
 #[test(tokio::test)]
 async fn openai_bad_request_error() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -3760,7 +3760,7 @@ async fn openai_bad_request_error() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn openai_stream_error() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -3827,7 +3827,7 @@ async fn openai_stream_error() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn chunker_internal_server_error() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -4070,7 +4070,7 @@ async fn chunker_internal_server_error() -> Result<(), anyhow::Error> {
         then.internal_server_error();
     });
 
-    let pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
 
     let test_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -4117,7 +4117,7 @@ async fn chunker_internal_server_error() -> Result<(), anyhow::Error> {
 
 #[test(tokio::test)]
 async fn detector_internal_server_error() -> Result<(), anyhow::Error> {
-    let mut openai_server = MockServer::new("openai");
+    let mut openai_server = MockServer::new_http("openai");
     openai_server.mock(|when, then| {
         when.post()
             .path(CHAT_COMPLETIONS_ENDPOINT)
@@ -4397,7 +4397,7 @@ async fn detector_internal_server_error() -> Result<(), anyhow::Error> {
         ]);
     });
 
-    let mut pii_detector_sentence_server = MockServer::new("pii_detector_sentence");
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
     pii_detector_sentence_server.mock(|when, then| {
         when.post()
             .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)

--- a/tests/chat_completions_unary.rs
+++ b/tests/chat_completions_unary.rs
@@ -549,9 +549,7 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -708,9 +706,7 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -935,9 +931,7 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -1113,9 +1107,7 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)

--- a/tests/chat_completions_unary.rs
+++ b/tests/chat_completions_unary.rs
@@ -124,7 +124,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mut mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
+    let mut mock_openai_server = MockServer::new_http("openai").with_mocks(chat_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -342,8 +342,8 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(chat_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -547,8 +547,8 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -704,8 +704,8 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -929,8 +929,8 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -1105,8 +1105,8 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(chat_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(chat_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()

--- a/tests/chat_detection.rs
+++ b/tests/chat_detection.rs
@@ -93,7 +93,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -163,7 +163,7 @@ async fn detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
@@ -230,7 +230,7 @@ async fn client_errors() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])

--- a/tests/classification_with_text_gen.rs
+++ b/tests/classification_with_text_gen.rs
@@ -272,7 +272,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
 
     // Configure mock servers
     let mock_detector_server =
-        MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
@@ -516,7 +516,7 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
-        MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -718,7 +718,7 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
-        MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -996,7 +996,7 @@ async fn output_detector_detections() -> Result<(), anyhow::Error> {
     // Configure mock servers
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_detector_server =
-        MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     // Run test orchestrator server
@@ -1221,7 +1221,7 @@ async fn output_detector_client_error() -> Result<(), anyhow::Error> {
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
-        MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()

--- a/tests/classification_with_text_gen.rs
+++ b/tests/classification_with_text_gen.rs
@@ -94,7 +94,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     });
 
     // Configure mock servers
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -273,10 +273,8 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     // Configure mock servers
     let mock_detector_server =
         MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -515,10 +513,8 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
     });
 
     // Configure mock servers
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
         MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
 
@@ -719,10 +715,8 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Configure mock servers
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
         MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
 
@@ -1000,12 +994,10 @@ async fn output_detector_detections() -> Result<(), anyhow::Error> {
     });
 
     // Configure mock servers
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_detector_server =
         MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -1226,10 +1218,8 @@ async fn output_detector_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Configure mock servers
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
         MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
 

--- a/tests/completions_detection.rs
+++ b/tests/completions_detection.rs
@@ -466,9 +466,7 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(tokenize_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -607,9 +605,7 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(completions_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -832,9 +828,7 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(completion_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -992,9 +986,7 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
     let mock_openai_server = MockServer::new("openai").with_mocks(completion_mocks);
-    let mock_chunker_server = MockServer::new(CHUNKER_NAME_SENTENCE)
-        .grpc()
-        .with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)

--- a/tests/completions_detection.rs
+++ b/tests/completions_detection.rs
@@ -117,7 +117,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_openai_server = MockServer::new("openai").with_mocks(completion_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(completion_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -262,8 +262,8 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(completion_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(completion_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -464,8 +464,8 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(tokenize_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(tokenize_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -603,8 +603,8 @@ async fn input_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(completions_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(completions_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -826,8 +826,8 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(completion_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(completion_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -984,8 +984,8 @@ async fn output_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_openai_server = MockServer::new("openai").with_mocks(completion_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
+    let mock_openai_server = MockServer::new_http("openai").with_mocks(completion_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()

--- a/tests/context_docs_detection.rs
+++ b/tests/context_docs_detection.rs
@@ -72,7 +72,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
@@ -134,7 +134,7 @@ async fn detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
@@ -194,7 +194,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])

--- a/tests/detection_on_generation.rs
+++ b/tests/detection_on_generation.rs
@@ -73,7 +73,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
@@ -133,7 +133,7 @@ async fn detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])
@@ -190,7 +190,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])

--- a/tests/generation_with_detection.rs
+++ b/tests/generation_with_detection.rs
@@ -95,7 +95,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&mock_generation_server)
@@ -177,7 +177,7 @@ async fn detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&mock_generation_server)
@@ -267,7 +267,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&mock_generation_server)

--- a/tests/generation_with_detection.rs
+++ b/tests/generation_with_detection.rs
@@ -94,7 +94,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -176,7 +176,7 @@ async fn detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -266,7 +266,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)

--- a/tests/streaming_classification_with_gen.rs
+++ b/tests/streaming_classification_with_gen.rs
@@ -117,7 +117,7 @@ async fn no_detectors() -> Result<(), anyhow::Error> {
     });
 
     // Configure mock servers
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -281,9 +281,9 @@ async fn input_detector_no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&generation_server)
@@ -431,9 +431,9 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
         .with_mocks(whole_doc_detection_mocks);
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&generation_server)
@@ -651,9 +651,9 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
-    let mock_generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .chunker_servers([&mock_chunker_server])
@@ -1110,12 +1110,12 @@ async fn output_detectors_no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
         MockServer::new(angle_brackets_detector).with_mocks(detection_mocks.clone());
     let mock_parenthesis_detector_server =
         MockServer::new(parenthesis_detector).with_mocks(detection_mocks);
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -1392,12 +1392,12 @@ async fn output_detectors_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
         MockServer::new(angle_brackets_detector).with_mocks(angle_brackets_mocks);
     let mock_parenthesis_detector_server =
         MockServer::new(parenthesis_detector).with_mocks(parenthesis_mocks);
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&generation_server)
@@ -1752,9 +1752,9 @@ async fn output_detector_client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
-    let generation_server = MockServer::new("nlp").grpc().with_mocks(generation_mocks);
+    let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .generation_server(&generation_server)

--- a/tests/streaming_classification_with_gen.rs
+++ b/tests/streaming_classification_with_gen.rs
@@ -282,7 +282,7 @@ async fn input_detector_no_detections() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -427,12 +427,13 @@ async fn input_detector_detections() -> Result<(), anyhow::Error> {
             });
         then.json([vec![&whole_doc_mock_detection_response]]);
     });
-    let mock_whole_doc_detector_server = MockServer::new(DETECTOR_NAME_ANGLE_BRACKETS_WHOLE_DOC)
-        .with_mocks(whole_doc_detection_mocks);
+    let mock_whole_doc_detector_server =
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_WHOLE_DOC)
+            .with_mocks(whole_doc_detection_mocks);
 
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -652,7 +653,7 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detector_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detector_mocks);
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -1112,9 +1113,9 @@ async fn output_detectors_no_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
-        MockServer::new(angle_brackets_detector).with_mocks(detection_mocks.clone());
+        MockServer::new_http(angle_brackets_detector).with_mocks(detection_mocks.clone());
     let mock_parenthesis_detector_server =
-        MockServer::new(parenthesis_detector).with_mocks(detection_mocks);
+        MockServer::new_http(parenthesis_detector).with_mocks(detection_mocks);
     let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
 
     let orchestrator_server = TestOrchestratorServer::builder()
@@ -1394,9 +1395,9 @@ async fn output_detectors_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
-        MockServer::new(angle_brackets_detector).with_mocks(angle_brackets_mocks);
+        MockServer::new_http(angle_brackets_detector).with_mocks(angle_brackets_mocks);
     let mock_parenthesis_detector_server =
-        MockServer::new(parenthesis_detector).with_mocks(parenthesis_mocks);
+        MockServer::new_http(parenthesis_detector).with_mocks(parenthesis_mocks);
     let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
@@ -1753,7 +1754,7 @@ async fn output_detector_client_error() -> Result<(), anyhow::Error> {
 
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)

--- a/tests/streaming_content_detection.rs
+++ b/tests/streaming_content_detection.rs
@@ -135,9 +135,9 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     // Run test orchestrator server
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
-        MockServer::new(angle_brackets_detector).with_mocks(detection_mocks.clone());
+        MockServer::new_http(angle_brackets_detector).with_mocks(detection_mocks.clone());
     let mock_parenthesis_detector_server =
-        MockServer::new(parenthesis_detector).with_mocks(detection_mocks);
+        MockServer::new_http(parenthesis_detector).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([
@@ -371,9 +371,9 @@ async fn detections() -> Result<(), anyhow::Error> {
     // Run test orchestrator server
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
-        MockServer::new(angle_brackets_detector).with_mocks(angle_brackets_detection_mocks);
+        MockServer::new_http(angle_brackets_detector).with_mocks(angle_brackets_detection_mocks);
     let mock_parenthesis_detector_server =
-        MockServer::new(parenthesis_detector).with_mocks(parenthesis_detection_mocks);
+        MockServer::new_http(parenthesis_detector).with_mocks(parenthesis_detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([
@@ -559,7 +559,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
 
     // Run test orchestrator server
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])

--- a/tests/streaming_content_detection.rs
+++ b/tests/streaming_content_detection.rs
@@ -133,7 +133,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Run test orchestrator server
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
         MockServer::new(angle_brackets_detector).with_mocks(detection_mocks.clone());
     let mock_parenthesis_detector_server =
@@ -369,7 +369,7 @@ async fn detections() -> Result<(), anyhow::Error> {
     });
 
     // Run test orchestrator server
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_angle_brackets_detector_server =
         MockServer::new(angle_brackets_detector).with_mocks(angle_brackets_detection_mocks);
     let mock_parenthesis_detector_server =
@@ -558,7 +558,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
     });
 
     // Run test orchestrator server
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)

--- a/tests/text_content_detection.rs
+++ b/tests/text_content_detection.rs
@@ -113,9 +113,9 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_sentence_detector_server =
-        MockServer::new(sentence_detector).with_mocks(sentence_detector_mocks);
+        MockServer::new_http(sentence_detector).with_mocks(sentence_detector_mocks);
     let mock_whole_doc_detector_server =
-        MockServer::new(whole_doc_detector).with_mocks(whole_doc_detector_mocks);
+        MockServer::new_http(whole_doc_detector).with_mocks(whole_doc_detector_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .chunker_servers([&mock_chunker_server])
@@ -255,9 +255,9 @@ async fn detections() -> Result<(), anyhow::Error> {
     // Start orchestrator server and its dependencies
     let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_whole_doc_detector_server =
-        MockServer::new(whole_doc_detector).with_mocks(whole_doc_detector_mocks);
+        MockServer::new_http(whole_doc_detector).with_mocks(whole_doc_detector_mocks);
     let mock_sentence_detector_server =
-        MockServer::new(sentence_detector).with_mocks(sentence_detector_mocks);
+        MockServer::new_http(sentence_detector).with_mocks(sentence_detector_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .chunker_servers([&mock_chunker_server])
@@ -365,7 +365,7 @@ async fn client_error() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_detector_server = MockServer::new(detector_name).with_mocks(detection_mocks);
+    let mock_detector_server = MockServer::new_http(detector_name).with_mocks(detection_mocks);
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .detector_servers([&mock_detector_server])

--- a/tests/text_content_detection.rs
+++ b/tests/text_content_detection.rs
@@ -111,7 +111,7 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_sentence_detector_server =
         MockServer::new(sentence_detector).with_mocks(sentence_detector_mocks);
     let mock_whole_doc_detector_server =
@@ -253,7 +253,7 @@ async fn detections() -> Result<(), anyhow::Error> {
     });
 
     // Start orchestrator server and its dependencies
-    let mock_chunker_server = MockServer::new(chunker_id).grpc().with_mocks(chunker_mocks);
+    let mock_chunker_server = MockServer::new_grpc(chunker_id).with_mocks(chunker_mocks);
     let mock_whole_doc_detector_server =
         MockServer::new(whole_doc_detector).with_mocks(whole_doc_detector_mocks);
     let mock_sentence_detector_server =


### PR DESCRIPTION
This PR upgrades mocktail to `0.3.0` and updates tests to use `MockServer::new_grpc()` as the `.grpc()` builder method has been deprecated. While optional, this also updates tests to use `MockServer::new_http()`, preferred over less explicit `MockServer::new()`.

Closes #454 