### PR TITLE
Add Chat Completions Streaming support for continuous_usage_stats

### DIFF
--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -14,12 +14,8 @@
  limitations under the License.
 
 */
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, sync::Arc};
 
-use dashmap::DashMap;
 use futures::{StreamExt, TryStreamExt, stream};
 use opentelemetry::trace::TraceId;
 use tokio::sync::mpsc;
@@ -37,8 +33,8 @@ use crate::{
         Context, Error,
         common::{self, text_contents_detections, validate_detectors},
         types::{
-            ChatCompletionBatcher, ChatCompletionStream, ChatMessageIterator, ChoiceIndex, Chunk,
-            DetectionBatchStream, Detections,
+            ChatCompletionBatcher, ChatCompletionStream, ChatMessageIterator, Chunk,
+            CompletionState, DetectionBatchStream, Detections,
         },
     },
 };
@@ -237,7 +233,7 @@ async fn handle_output_detection(
         detectors.into_iter().partition(|(detector_id, _)| {
             ctx.config.get_chunker_id(detector_id).unwrap() == "whole_doc_chunker"
         });
-    let chat_completion_state = Arc::new(ChatCompletionState::new());
+    let completion_state = Arc::new(CompletionState::new());
 
     if !detectors.is_empty() {
         // Set up streaming detection pipeline
@@ -279,7 +275,7 @@ async fn handle_output_detection(
         tokio::spawn(process_chat_completion_stream(
             trace_id,
             chat_completion_stream,
-            Some(chat_completion_state.clone()),
+            Some(completion_state.clone()),
             Some(input_txs),
             None,
         ));
@@ -290,7 +286,7 @@ async fn handle_output_detection(
         );
         process_detection_batch_stream(
             trace_id,
-            chat_completion_state.clone(),
+            completion_state.clone(),
             detection_batch_stream,
             response_tx.clone(),
         )
@@ -301,7 +297,7 @@ async fn handle_output_detection(
         process_chat_completion_stream(
             trace_id,
             chat_completion_stream,
-            Some(chat_completion_state.clone()),
+            Some(completion_state.clone()),
             None,
             Some(response_tx.clone()),
         )
@@ -310,12 +306,12 @@ async fn handle_output_detection(
     // NOTE: at this point, the chat completions stream has been fully consumed and chat completion state is final
 
     // If whole doc output detections or usage is requested, a final message is sent with these items
-    if !whole_doc_detectors.is_empty() || chat_completion_state.usage().is_some() {
+    if !whole_doc_detectors.is_empty() || completion_state.usage().is_some() {
         let mut chat_completion = ChatCompletionChunk {
-            id: chat_completion_state.id(),
-            created: chat_completion_state.created(),
-            model: chat_completion_state.model(),
-            usage: chat_completion_state.usage(),
+            id: completion_state.id().unwrap().to_string(),
+            created: completion_state.created().unwrap(),
+            model: completion_state.model().unwrap().to_string(),
+            usage: completion_state.usage().cloned(),
             ..Default::default()
         };
         if !whole_doc_detectors.is_empty() {
@@ -324,7 +320,7 @@ async fn handle_output_detection(
                 ctx.clone(),
                 task,
                 whole_doc_detectors,
-                chat_completion_state,
+                completion_state,
             )
             .await
             {
@@ -352,7 +348,7 @@ async fn handle_output_detection(
 async fn process_chat_completion_stream(
     trace_id: TraceId,
     mut chat_completion_stream: ChatCompletionStream,
-    chat_completion_state: Option<Arc<ChatCompletionState>>,
+    completion_state: Option<Arc<CompletionState<ChatCompletionChunk>>>,
     input_txs: Option<HashMap<u32, mpsc::Sender<Result<(usize, String), Error>>>>,
     response_tx: Option<mpsc::Sender<Result<Option<ChatCompletionChunk>, Error>>>,
 ) {
@@ -372,42 +368,37 @@ async fn process_chat_completion_stream(
                         return;
                     }
                 }
-                if chat_completion.usage.is_some() && chat_completion.choices.is_empty() {
-                    // Update state: set final usage
+                if let Some(usage) = &chat_completion.usage
+                    && chat_completion.choices.is_empty()
+                {
+                    // Update state: set usage
                     // NOTE: this message has no choices and is not sent to detection input channel
-                    if let Some(state) = &chat_completion_state {
-                        *state.usage.lock().unwrap() = chat_completion.usage.clone();
+                    if let Some(state) = &completion_state {
+                        state.set_usage(usage.clone());
                     }
                 } else {
                     if message_index == 0 {
                         // Update state: set metadata
                         // NOTE: these values are the same for all chat completion chunks
-                        if let Some(state) = &chat_completion_state {
-                            let mut metadata = state.metadata.lock().unwrap();
-                            metadata.id = chat_completion.id.clone();
-                            metadata.created = chat_completion.created;
-                            metadata.model = chat_completion.model.clone();
+                        if let Some(state) = &completion_state {
+                            state.set_metadata(
+                                chat_completion.id.clone(),
+                                chat_completion.created,
+                                chat_completion.model.clone(),
+                            );
                         }
                     }
                     // NOTE: chat completion chunks should contain only 1 choice
                     if let Some(choice) = chat_completion.choices.first() {
                         // Extract choice text
                         let choice_text = choice.delta.content.clone().unwrap_or_default();
-                        // Update state: insert chat completion for this choice index
-                        if let Some(state) = &chat_completion_state {
-                            match state.chat_completions.entry(choice.index) {
-                                dashmap::Entry::Occupied(mut entry) => {
-                                    entry
-                                        .get_mut()
-                                        .insert(message_index, chat_completion.clone());
-                                }
-                                dashmap::Entry::Vacant(entry) => {
-                                    entry.insert(BTreeMap::from([(
-                                        message_index,
-                                        chat_completion.clone(),
-                                    )]));
-                                }
-                            }
+                        // Update state: insert completion
+                        if let Some(state) = &completion_state {
+                            state.insert_completion(
+                                choice.index,
+                                message_index,
+                                chat_completion.clone(),
+                            );
                         }
                         // Send choice text to detection input channel
                         if let Some(input_tx) =
@@ -446,11 +437,11 @@ async fn handle_whole_doc_output_detection(
     ctx: Arc<Context>,
     task: &ChatCompletionsDetectionTask,
     detectors: HashMap<String, DetectorParams>,
-    chat_completion_state: Arc<ChatCompletionState>,
+    completion_state: Arc<CompletionState<ChatCompletionChunk>>,
 ) -> Result<(OpenAiDetections, Vec<OrchestratorWarning>), Error> {
     // Create vec of choice_index->inputs, where inputs contains the concatenated text for the choice
-    let choice_inputs = chat_completion_state
-        .chat_completions
+    let choice_inputs = completion_state
+        .completions
         .iter()
         .map(|entry| {
             let choice_index = *entry.key();
@@ -508,16 +499,13 @@ async fn handle_whole_doc_output_detection(
 
 /// Builds a response with output detections.
 fn output_detection_response(
-    chat_completion_state: &Arc<ChatCompletionState>,
+    completion_state: &Arc<CompletionState<ChatCompletionChunk>>,
     choice_index: u32,
     chunk: Chunk,
     detections: Detections,
 ) -> Result<ChatCompletionChunk, Error> {
     // Get chat completions for this choice index
-    let chat_completions = chat_completion_state
-        .chat_completions
-        .get(&choice_index)
-        .unwrap();
+    let chat_completions = completion_state.completions.get(&choice_index).unwrap();
     // Get range of chat completions for this chunk
     let chat_completions = chat_completions
         .range(chunk.input_start_index..=chunk.input_end_index)
@@ -581,7 +569,7 @@ fn merge_logprobs(chat_completions: &[ChatCompletionChunk]) -> Option<ChatComple
 /// Consumes a detection batch stream, builds responses, and sends them to a response channel.
 async fn process_detection_batch_stream(
     trace_id: TraceId,
-    chat_completion_state: Arc<ChatCompletionState>,
+    completion_state: Arc<CompletionState<ChatCompletionChunk>>,
     mut detection_batch_stream: DetectionBatchStream,
     response_tx: mpsc::Sender<Result<Option<ChatCompletionChunk>, Error>>,
 ) {
@@ -589,12 +577,8 @@ async fn process_detection_batch_stream(
         match result {
             Ok((choice_index, chunk, detections)) => {
                 let input_end_index = chunk.input_end_index;
-                match output_detection_response(
-                    &chat_completion_state,
-                    choice_index,
-                    chunk,
-                    detections,
-                ) {
+                match output_detection_response(&completion_state, choice_index, chunk, detections)
+                {
                     Ok(chat_completion) => {
                         // Send chat completion to response channel
                         debug!(%trace_id, %choice_index, ?chat_completion, "sending chat completion chunk to response channel");
@@ -603,10 +587,8 @@ async fn process_detection_batch_stream(
                             return;
                         }
                         // If this is the final chat completion chunk with content, send chat completion chunk with finish reason
-                        let chat_completions = chat_completion_state
-                            .chat_completions
-                            .get(&choice_index)
-                            .unwrap();
+                        let chat_completions =
+                            completion_state.completions.get(&choice_index).unwrap();
                         if chat_completions.keys().rev().nth(1) == Some(&input_end_index) {
                             if let Some((_, chat_completion)) = chat_completions.last_key_value() {
                                 if chat_completion
@@ -644,46 +626,4 @@ async fn process_detection_batch_stream(
         }
     }
     info!(%trace_id, "task completed: detection batch stream closed");
-}
-
-#[derive(Debug, Default)]
-struct ChatCompletionMetadata {
-    /// A unique identifier for the chat completion. Each chunk has the same ID.
-    pub id: String,
-    /// The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
-    pub created: i64,
-    /// The model to generate the completion.
-    pub model: String,
-}
-
-#[derive(Debug, Default)]
-struct ChatCompletionState {
-    /// Chat completion metadata.
-    pub metadata: Mutex<ChatCompletionMetadata>,
-    /// A map of chat completion chunks received for each choice.
-    pub chat_completions: DashMap<ChoiceIndex, BTreeMap<usize, ChatCompletionChunk>>,
-    /// Final usage statistics.
-    pub usage: Mutex<Option<Usage>>,
-}
-
-impl ChatCompletionState {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn id(&self) -> String {
-        self.metadata.lock().unwrap().id.clone()
-    }
-
-    pub fn created(&self) -> i64 {
-        self.metadata.lock().unwrap().created
-    }
-
-    pub fn model(&self) -> String {
-        self.metadata.lock().unwrap().model.clone()
-    }
-
-    pub fn usage(&self) -> Option<Usage> {
-        self.usage.lock().unwrap().clone()
-    }
 }

--- a/src/orchestrator/types.rs
+++ b/src/orchestrator/types.rs
@@ -28,6 +28,8 @@ pub mod detection_batcher;
 pub use detection_batcher::*;
 pub mod detection_batch_stream;
 pub use detection_batch_stream::*;
+pub mod completion_state;
+pub use completion_state::*;
 
 use super::Error;
 use crate::{

--- a/src/orchestrator/types/completion_state.rs
+++ b/src/orchestrator/types/completion_state.rs
@@ -1,0 +1,80 @@
+use std::{collections::BTreeMap, sync::OnceLock};
+
+use dashmap::DashMap;
+
+use super::ChoiceIndex;
+use crate::clients::openai::Usage;
+
+/// Completion state for a streaming completions task.
+#[derive(Debug, Default)]
+pub struct CompletionState<T> {
+    /// Completion metadata.
+    pub metadata: OnceLock<CompletionMetadata>,
+    /// Completion chunks received for each choice.
+    pub completions: DashMap<ChoiceIndex, BTreeMap<usize, T>>,
+    /// Completion usage statistics.
+    pub usage: OnceLock<Usage>,
+}
+
+impl<T> CompletionState<T>
+where
+    T: Default,
+{
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets metadata.
+    pub fn set_metadata(&self, id: String, created: i64, model: String) {
+        let _ = self.metadata.set(CompletionMetadata { id, created, model });
+    }
+
+    /// Sets usage.
+    pub fn set_usage(&self, usage: Usage) {
+        let _ = self.usage.set(usage);
+    }
+
+    /// Inserts a completion.
+    pub fn insert_completion(
+        &self,
+        choice_index: ChoiceIndex,
+        message_index: usize,
+        completion: T,
+    ) {
+        match self.completions.entry(choice_index) {
+            dashmap::Entry::Occupied(mut entry) => {
+                entry.get_mut().insert(message_index, completion);
+            }
+            dashmap::Entry::Vacant(entry) => {
+                entry.insert(BTreeMap::from([(message_index, completion)]));
+            }
+        }
+    }
+
+    pub fn id(&self) -> Option<&str> {
+        self.metadata.get().map(|v| v.id.as_ref())
+    }
+
+    pub fn created(&self) -> Option<i64> {
+        self.metadata.get().map(|v| v.created)
+    }
+
+    pub fn model(&self) -> Option<&str> {
+        self.metadata.get().map(|v| v.model.as_ref())
+    }
+
+    pub fn usage(&self) -> Option<&Usage> {
+        self.usage.get()
+    }
+}
+
+/// Completion metadata common to all chunks.
+#[derive(Debug, Default)]
+pub struct CompletionMetadata {
+    /// A unique identifier for the completion.
+    pub id: String,
+    /// The Unix timestamp (in seconds) of when the completion was created.
+    pub created: i64,
+    /// The model to generate the completion.
+    pub model: String,
+}

--- a/tests/chat_completions_streaming.rs
+++ b/tests/chat_completions_streaming.rs
@@ -1761,9 +1761,9 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
                 created: 1749227854,
                 model: "test-0B".into(),
                 usage: Some(Usage {
-                    prompt_tokens: 18,
-                    total_tokens: 64,
-                    completion_tokens: 46,
+                    prompt_tokens: 19,
+                    total_tokens: 49,
+                    completion_tokens: 30,
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -2058,16 +2058,647 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
         "missing finish reason message"
     );
 
-    // Validate usage message
+    // Validate final usage message
     assert_eq!(
         messages[4].usage,
         Some(Usage {
-            prompt_tokens: 18,
-            total_tokens: 64,
-            completion_tokens: 46,
+            prompt_tokens: 19,
+            total_tokens: 49,
+            completion_tokens: 30,
             ..Default::default()
         }),
-        "missing usage message"
+        "unexpected usage for final usage message"
+    );
+
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn output_detectors_with_continuous_usage_stats() -> Result<(), anyhow::Error> {
+    let mut openai_server = MockServer::new_http("openai");
+    openai_server.mock(|when, then| {
+        when.post()
+            .path(CHAT_COMPLETIONS_ENDPOINT)
+            .json(json!({
+                "stream": true,
+                "model": "test-0B",
+                "messages": [
+                    Message { role: Role::User, content: Some(Content::Text("Can you generate 2 random phone numbers?".into())), ..Default::default()},
+                ],
+                "stream_options": {
+                    "include_usage": true,
+                    "continuous_usage_stats": true
+                }
+            })
+        );
+        then.text_stream(sse([
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        role: Some(Role::Assistant),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 19,
+                    completion_tokens: 0,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some("Here".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 20,
+                    completion_tokens: 1,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some(" are".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 21,
+                    completion_tokens: 2,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some(" ".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 22,
+                    completion_tokens: 3,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some("2".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 23,
+                    completion_tokens: 4,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some(" random".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 24,
+                    completion_tokens: 5,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some(" phone".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 25,
+                    completion_tokens: 6,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some(" numbers".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 26,
+                    completion_tokens: 7,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some(":\n\n".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 28,
+                    completion_tokens: 8,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some("1. (503) 272-8192\n".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 38,
+                    completion_tokens: 19,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    delta: ChatCompletionDelta {
+                        content: Some("2. (617) 985-3519.".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 49,
+                    completion_tokens: 30,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                choices: vec![ChatCompletionChunkChoice {
+                    index: 0,
+                    finish_reason: Some("stop".into()),
+                    ..Default::default()
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 49,
+                    completion_tokens: 30,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ChatCompletionChunk {
+                id: "chatcmpl-test".into(),
+                object: "chat.completion.chunk".into(),
+                created: 1749227854,
+                model: "test-0B".into(),
+                usage: Some(Usage {
+                    prompt_tokens: 19,
+                    total_tokens: 49,
+                    completion_tokens: 30,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ]));
+    });
+
+    let mut sentence_chunker_server = MockServer::new_grpc("sentence_chunker");
+    sentence_chunker_server.mock(|when, then| {
+        when.post()
+            .path(CHUNKER_STREAMING_ENDPOINT)
+            .header(CHUNKER_MODEL_ID_HEADER_NAME, "sentence_chunker")
+            .pb_stream(vec![
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: "Here".into(),
+                    input_index_stream: 1,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: " are".into(),
+                    input_index_stream: 2,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: " ".into(),
+                    input_index_stream: 3,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: "2".into(),
+                    input_index_stream: 4,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: " random".into(),
+                    input_index_stream: 5,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: " phone".into(),
+                    input_index_stream: 6,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: " numbers".into(),
+                    input_index_stream: 7,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: ":\n\n".into(),
+                    input_index_stream: 8,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: "1. (503) 272-8192\n".into(),
+                    input_index_stream: 9,
+                },
+                BidiStreamingChunkerTokenizationTaskRequest {
+                    text_stream: "2. (617) 985-3519.".into(),
+                    input_index_stream: 10,
+                },
+            ]);
+        then.pb_stream(vec![
+            ChunkerTokenizationStreamResult {
+                results: vec![Token {
+                    start: 0,
+                    end: 32,
+                    text: "Here are 2 random phone numbers:".into(),
+                }],
+                token_count: 0,
+                processed_index: 32,
+                start_index: 0,
+                input_start_index: 1,
+                input_end_index: 8,
+            },
+            ChunkerTokenizationStreamResult {
+                results: vec![Token {
+                    start: 32,
+                    end: 51,
+                    text: "\n\n1. (503) 272-8192".into(),
+                }],
+                token_count: 0,
+                processed_index: 51,
+                start_index: 32,
+                input_start_index: 9,
+                input_end_index: 9,
+            },
+            ChunkerTokenizationStreamResult {
+                results: vec![Token {
+                    start: 51,
+                    end: 70,
+                    text: "\n2. (617) 985-3519.".into(),
+                }],
+                token_count: 0,
+                processed_index: 70,
+                start_index: 51,
+                input_start_index: 10,
+                input_end_index: 10,
+            },
+        ]);
+    });
+
+    let mut pii_detector_sentence_server = MockServer::new_http("pii_detector_sentence");
+    pii_detector_sentence_server.mock(|when, then| {
+        when.post()
+            .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
+            .header("detector-id", PII_DETECTOR_SENTENCE)
+            .json(ContentAnalysisRequest {
+                contents: vec!["Here are 2 random phone numbers:".into()],
+                detector_params: DetectorParams::default(),
+            });
+        then.json(json!([[]]));
+    });
+    pii_detector_sentence_server.mock(|when, then| {
+        when.post()
+            .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
+            .header("detector-id", PII_DETECTOR_SENTENCE)
+            .json(ContentAnalysisRequest {
+                contents: vec!["\n\n1. (503) 272-8192".into()],
+                detector_params: DetectorParams::default(),
+            });
+        then.json(json!([
+        [
+            {
+                "start": 5,
+                "end": 19,
+                "detection": "PhoneNumber",
+                "detection_type": "pii",
+                "score": 0.8,
+                "text": "(503) 272-8192",
+                "evidences": []
+            }
+        ]]));
+    });
+    pii_detector_sentence_server.mock(|when, then| {
+        when.post()
+            .path(TEXT_CONTENTS_DETECTOR_ENDPOINT)
+            .header("detector-id", PII_DETECTOR_SENTENCE)
+            .json(ContentAnalysisRequest {
+                contents: vec!["\n2. (617) 985-3519.".into()],
+                detector_params: DetectorParams::default(),
+            });
+        then.json(json!([
+        [
+            {
+                "start": 4,
+                "end": 18,
+                "detection": "PhoneNumber",
+                "detection_type": "pii",
+                "score": 0.8,
+                "text": "(617) 985-3519",
+                "evidences": []
+            }
+        ]]));
+    });
+
+    let test_server = TestOrchestratorServer::builder()
+        .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
+        .openai_server(&openai_server)
+        .chunker_servers([&sentence_chunker_server])
+        .detector_servers([&pii_detector_sentence_server])
+        .build()
+        .await?;
+
+    let response = test_server
+        .post(ORCHESTRATOR_CHAT_COMPLETIONS_DETECTION_ENDPOINT)
+        .json(&json!({
+            "stream": true,
+            "model": "test-0B",
+            "detectors": {
+                "input": {},
+                "output": {
+                    "pii_detector_sentence": {},
+                },
+            },
+            "messages": [
+                Message { role: Role::User, content: Some(Content::Text("Can you generate 2 random phone numbers?".into())), ..Default::default()},
+            ],
+            "stream_options": {
+                "include_usage": true,
+                "continuous_usage_stats": true
+            }
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let sse_stream: SseStream<ChatCompletionChunk> = SseStream::new(response.bytes_stream());
+    let messages = sse_stream.try_collect::<Vec<_>>().await?;
+    debug!("{messages:#?}");
+
+    // Validate length
+    assert_eq!(messages.len(), 5, "unexpected number of messages");
+
+    // Validate msg-0 choices
+    assert_eq!(
+        messages[0].choices,
+        vec![ChatCompletionChunkChoice {
+            index: 0,
+            delta: ChatCompletionDelta {
+                role: Some(Role::Assistant),
+                content: Some("Here are 2 random phone numbers:".into(),),
+                refusal: None,
+                tool_calls: vec![],
+            },
+            ..Default::default()
+        }],
+        "unexpected choices for msg-0"
+    );
+    // Validate msg-0 detections
+    assert_eq!(
+        messages[0].detections,
+        Some(OpenAiDetections {
+            input: vec![],
+            output: vec![OutputDetectionResult {
+                choice_index: 0,
+                results: vec![],
+            }],
+        }),
+        "unexpected detections for msg-0"
+    );
+    // Validate msg-0 usage
+    assert_eq!(
+        messages[0].usage,
+        Some(Usage {
+            prompt_tokens: 19,
+            total_tokens: 28,
+            completion_tokens: 8,
+            ..Default::default()
+        }),
+        "unexpected usage for msg-0"
+    );
+
+    // Validate msg-1 choices
+    assert_eq!(
+        messages[1].choices,
+        vec![ChatCompletionChunkChoice {
+            index: 0,
+            delta: ChatCompletionDelta {
+                role: Some(Role::Assistant),
+                content: Some("\n\n1. (503) 272-8192".into(),),
+                refusal: None,
+                tool_calls: vec![],
+            },
+            ..Default::default()
+        }],
+        "unexpected choices for msg-1"
+    );
+    // Validate msg-2 detections
+    assert_eq!(
+        messages[1].detections,
+        Some(OpenAiDetections {
+            input: vec![],
+            output: vec![OutputDetectionResult {
+                choice_index: 0,
+                results: vec![ContentAnalysisResponse {
+                    start: 5,
+                    end: 19,
+                    text: "(503) 272-8192".into(),
+                    detection: "PhoneNumber".into(),
+                    detection_type: "pii".into(),
+                    detector_id: Some("pii_detector_sentence".into()),
+                    score: 0.8,
+                    ..Default::default()
+                }],
+            }],
+        }),
+        "unexpected detections for msg-1"
+    );
+    // Validate msg-1 usage
+    assert_eq!(
+        messages[1].usage,
+        Some(Usage {
+            prompt_tokens: 19,
+            total_tokens: 38,
+            completion_tokens: 19,
+            ..Default::default()
+        }),
+        "unexpected usage for msg-1"
+    );
+
+    // Validate msg-2 choices
+    assert_eq!(
+        messages[2].choices,
+        vec![ChatCompletionChunkChoice {
+            index: 0,
+            delta: ChatCompletionDelta {
+                role: Some(Role::Assistant),
+                content: Some("\n2. (617) 985-3519.".into(),),
+                refusal: None,
+                tool_calls: vec![],
+            },
+            ..Default::default()
+        }],
+        "unexpected choices for msg-2"
+    );
+    // Validate msg-2 detections
+    assert_eq!(
+        messages[2].detections,
+        Some(OpenAiDetections {
+            input: vec![],
+            output: vec![OutputDetectionResult {
+                choice_index: 0,
+                results: vec![ContentAnalysisResponse {
+                    start: 4,
+                    end: 18,
+                    text: "(617) 985-3519".into(),
+                    detection: "PhoneNumber".into(),
+                    detection_type: "pii".into(),
+                    detector_id: Some("pii_detector_sentence".into()),
+                    score: 0.8,
+                    ..Default::default()
+                }],
+            }],
+        }),
+        "unexpected detections for msg-2"
+    );
+    // Validate msg-2 usage
+    assert_eq!(
+        messages[2].usage,
+        Some(Usage {
+            prompt_tokens: 19,
+            total_tokens: 49,
+            completion_tokens: 30,
+            ..Default::default()
+        }),
+        "unexpected usage for msg-2"
+    );
+
+    // Validate finish reason message
+    assert_eq!(
+        messages[3].choices[0].finish_reason,
+        Some("stop".into()),
+        "missing finish reason message"
+    );
+    // Validate finish reason message usage
+    assert_eq!(
+        messages[3].usage,
+        Some(Usage {
+            prompt_tokens: 19,
+            total_tokens: 49,
+            completion_tokens: 30,
+            ..Default::default()
+        }),
+        "unexpected usage for finish reason message"
+    );
+
+    // Validate final usage message
+    assert_eq!(
+        messages[4].usage,
+        Some(Usage {
+            prompt_tokens: 19,
+            total_tokens: 49,
+            completion_tokens: 30,
+            ..Default::default()
+        }),
+        "unexpected usage for final usage message"
     );
 
     Ok(())


### PR DESCRIPTION
Changes:
- Add `CompletionState` and drop `ChatCompletionState` **
  - This type holds state for streaming completions tasks and is now generic over the completion chunk type (`ChatCompletionChunk`, `Completion`) to reduce code duplication.
  - A few tweaks/enhancements:
    - Moved `usage` out of metadata as it isn't a metadata field
    - Replaced `Mutex` with `OnceLock` as `metadata` and `usage` are only set once, from the _first message_ and _usage message_, respectively
      - Error will be intentionally disregarded if they are set again, but this shouldn't happen anyway
    - Added convenience methods to improve ergonomics: `set_metadata`, `set_usage`, `insert_completion`
- Update logic to detect the _usage message_ for setting "final" `usage` state
  - The existing logic didn't work when `continuous_usage_stats` was requested as continuous `usage` is provided with every message
- Add `output_detectors_with_continuous_usage_stats` integration test
- Update `output_detectors_with_usage` integration test for alignment
- Update some comments

_** The `CompletionState` changes probably should be a separate PR, but leaving them in this PR unless requested to be split out._

Closes #445