### PR TITLE
Rename ChatCompletionBatcher to CompletionBatcher

### DIFF
--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -33,8 +33,8 @@ use crate::{
         Context, Error,
         common::{self, text_contents_detections, validate_detectors},
         types::{
-            ChatCompletionBatcher, ChatCompletionStream, ChatMessageIterator, Chunk,
-            CompletionState, DetectionBatchStream, Detections,
+            ChatCompletionStream, ChatMessageIterator, Chunk, CompletionBatcher, CompletionState,
+            DetectionBatchStream, Detections,
         },
     },
 };
@@ -280,10 +280,8 @@ async fn handle_output_detection(
             None,
         ));
         // Process detection streams and await completion
-        let detection_batch_stream = DetectionBatchStream::new(
-            ChatCompletionBatcher::new(detectors.len()),
-            detection_streams,
-        );
+        let detection_batch_stream =
+            DetectionBatchStream::new(CompletionBatcher::new(detectors.len()), detection_streams);
         process_detection_batch_stream(
             trace_id,
             completion_state.clone(),

--- a/src/orchestrator/types/detection_batcher.rs
+++ b/src/orchestrator/types/detection_batcher.rs
@@ -14,8 +14,8 @@
  limitations under the License.
 
 */
-pub mod chat_completion;
-pub use chat_completion::*;
+pub mod completion;
+pub use completion::*;
 pub mod max_processed_index;
 pub use max_processed_index::*;
 

--- a/src/orchestrator/types/detection_batcher/completion.rs
+++ b/src/orchestrator/types/detection_batcher/completion.rs
@@ -20,7 +20,7 @@ use super::{Batch, Chunk, DetectionBatcher, Detections};
 
 pub type ChoiceIndex = u32;
 
-/// A batcher for chat completions.
+/// A batcher for completions.
 ///
 /// A batch corresponds to a choice-chunk (where each chunk is associated
 /// with a particular choice through a ChoiceIndex). Batches are returned
@@ -36,14 +36,14 @@ pub type ChoiceIndex = u32;
 ///
 /// This batcher requires that all detectors use the same chunker.
 #[derive(Debug, Clone)]
-pub struct ChatCompletionBatcher {
+pub struct CompletionBatcher {
     n_detectors: usize,
     // We place the chunk first since chunk ordering includes where
     // the chunk is in all the processed messages.
     state: BTreeMap<(Chunk, ChoiceIndex), Vec<Detections>>,
 }
 
-impl ChatCompletionBatcher {
+impl CompletionBatcher {
     pub fn new(n_detectors: usize) -> Self {
         Self {
             n_detectors,
@@ -52,7 +52,7 @@ impl ChatCompletionBatcher {
     }
 }
 
-impl DetectionBatcher for ChatCompletionBatcher {
+impl DetectionBatcher for CompletionBatcher {
     fn push(&mut self, choice_index: ChoiceIndex, chunk: Chunk, detections: Detections) {
         match self.state.entry((chunk, choice_index)) {
             btree_map::Entry::Vacant(entry) => {
@@ -118,7 +118,7 @@ mod test {
 
         // Create a batcher that will process batches for 2 detectors
         let n_detectors = 2;
-        let mut batcher = ChatCompletionBatcher::new(n_detectors);
+        let mut batcher = CompletionBatcher::new(n_detectors);
 
         // Push chunk detections for pii detector
         batcher.push(
@@ -203,7 +203,7 @@ mod test {
 
         // Create a batcher that will process batches for 2 detectors
         let n_detectors = 2;
-        let mut batcher = ChatCompletionBatcher::new(n_detectors);
+        let mut batcher = CompletionBatcher::new(n_detectors);
 
         for choice_index in 0..choices {
             // Push chunk-2 detections for pii detector
@@ -326,7 +326,7 @@ mod test {
 
         // Create a batcher that will process batches for 2 detectors
         let n_detectors = 2;
-        let mut batcher = ChatCompletionBatcher::new(n_detectors);
+        let mut batcher = CompletionBatcher::new(n_detectors);
 
         // Intersperse choice detections
         // NOTE: There may be an edge case when chunk-2 (or later) detections are pushed
@@ -465,7 +465,7 @@ mod test {
 
         // Create a batcher that will process batches for 2 detectors
         let n_detectors = 2;
-        let batcher = ChatCompletionBatcher::new(n_detectors);
+        let batcher = CompletionBatcher::new(n_detectors);
 
         // Create detection batch stream
         let streams = vec![pii_detections_stream, hap_detections_stream];


### PR DESCRIPTION
Renaming as this batcher is used for both completions and chat completions streaming. Similar to `CompletionState`, we will use "completion" naming for common components.