### PR TITLE
Rename openai detection types

### DIFF
--- a/src/clients/openai.rs
+++ b/src/clients/openai.rs
@@ -684,10 +684,10 @@ pub struct ChatCompletion {
     pub service_tier: Option<String>,
     /// Detections
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detections: Option<OpenAiDetections>,
+    pub detections: Option<CompletionDetections>,
     /// Warnings
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub warnings: Vec<OrchestratorWarning>,
+    pub warnings: Vec<CompletionDetectionWarning>,
 }
 
 /// Helper to accept both string and integer for stop_reason.
@@ -787,10 +787,10 @@ pub struct ChatCompletionChunk {
     pub usage: Option<Usage>,
     /// Detections
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detections: Option<OpenAiDetections>,
+    pub detections: Option<CompletionDetections>,
     /// Warnings
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub warnings: Vec<OrchestratorWarning>,
+    pub warnings: Vec<CompletionDetectionWarning>,
 }
 
 impl Default for ChatCompletionChunk {
@@ -862,10 +862,10 @@ pub struct Completion {
     pub system_fingerprint: Option<String>,
     /// Detections
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detections: Option<OpenAiDetections>,
+    pub detections: Option<CompletionDetections>,
     /// Warnings
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub warnings: Vec<OrchestratorWarning>,
+    pub warnings: Vec<CompletionDetectionWarning>,
 }
 
 /// Completion (legacy) choice.
@@ -966,39 +966,39 @@ pub struct OpenAiErrorMessage {
     pub error: OpenAiError,
 }
 
-/// Guardrails Open AI detections.
+/// Guardrails completion detections.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
-pub struct OpenAiDetections {
+pub struct CompletionDetections {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub input: Vec<InputDetectionResult>,
+    pub input: Vec<CompletionInputDetections>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub output: Vec<OutputDetectionResult>,
+    pub output: Vec<CompletionOutputDetections>,
 }
 
-/// Guardrails Open AI input detections.
+/// Guardrails completion input detections.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct InputDetectionResult {
+pub struct CompletionInputDetections {
     pub message_index: u32,
     #[serde(default)]
     pub results: Vec<ContentAnalysisResponse>,
 }
 
-/// Guardrails Open AI output detections.
+/// Guardrails completion output detections.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct OutputDetectionResult {
+pub struct CompletionOutputDetections {
     pub choice_index: u32,
     #[serde(default)]
     pub results: Vec<ContentAnalysisResponse>,
 }
 
-/// Guardrails warning.
+/// Guardrails completion detection warning.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct OrchestratorWarning {
+pub struct CompletionDetectionWarning {
     r#type: DetectionWarningReason,
     message: String,
 }
 
-impl OrchestratorWarning {
+impl CompletionDetectionWarning {
     pub fn new(warning_type: DetectionWarningReason, message: &str) -> Self {
         Self {
             r#type: warning_type,

--- a/src/orchestrator/handlers/completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/completions_detection/streaming.rs
@@ -177,14 +177,14 @@ async fn handle_input_detection(
             id: Uuid::new_v4().simple().to_string(),
             model: model_id,
             created: common::current_timestamp().as_secs() as i64,
-            detections: Some(OpenAiDetections {
-                input: vec![InputDetectionResult {
+            detections: Some(CompletionDetections {
+                input: vec![CompletionInputDetections {
                     message_index: input_id,
                     results: detections.into(),
                 }],
                 ..Default::default()
             }),
-            warnings: vec![OrchestratorWarning::new(
+            warnings: vec![CompletionDetectionWarning::new(
                 DetectionWarningReason::UnsuitableInput,
                 UNSUITABLE_INPUT_MESSAGE,
             )],
@@ -416,7 +416,7 @@ async fn handle_whole_doc_output_detection(
     task: &CompletionsDetectionTask,
     detectors: HashMap<String, DetectorParams>,
     completion_state: Arc<CompletionState<Completion>>,
-) -> Result<(OpenAiDetections, Vec<OrchestratorWarning>), Error> {
+) -> Result<(CompletionDetections, Vec<CompletionDetectionWarning>), Error> {
     // Create vec of choice_index->inputs, where inputs contains the concatenated text for the choice
     let choice_inputs = completion_state
         .completions
@@ -454,21 +454,21 @@ async fn handle_whole_doc_output_detection(
     // Build output detections
     let output = choice_detections
         .into_iter()
-        .map(|(choice_index, detections)| OutputDetectionResult {
+        .map(|(choice_index, detections)| CompletionOutputDetections {
             choice_index,
             results: detections.into(),
         })
         .collect::<Vec<_>>();
     // Build warnings
     let warnings = if output.iter().any(|d| !d.results.is_empty()) {
-        vec![OrchestratorWarning::new(
+        vec![CompletionDetectionWarning::new(
             DetectionWarningReason::UnsuitableOutput,
             UNSUITABLE_OUTPUT_MESSAGE,
         )]
     } else {
         Vec::new()
     };
-    let detections = OpenAiDetections {
+    let detections = CompletionDetections {
         output,
         ..Default::default()
     };
@@ -499,14 +499,14 @@ fn output_detection_response(
         completion.choices[0].logprobs = logprobs;
         // Set warnings
         if !detections.is_empty() {
-            completion.warnings = vec![OrchestratorWarning::new(
+            completion.warnings = vec![CompletionDetectionWarning::new(
                 DetectionWarningReason::UnsuitableOutput,
                 UNSUITABLE_OUTPUT_MESSAGE,
             )];
         }
         // Set detections
-        completion.detections = Some(OpenAiDetections {
-            output: vec![OutputDetectionResult {
+        completion.detections = Some(CompletionDetections {
+            output: vec![CompletionOutputDetections {
                 choice_index,
                 results: detections.into(),
             }],

--- a/src/orchestrator/handlers/completions_detection/unary.rs
+++ b/src/orchestrator/handlers/completions_detection/unary.rs
@@ -140,14 +140,14 @@ async fn handle_input_detection(
             object: "text_completion".into(), // This value is constant: https://platform.openai.com/docs/api-reference/completions/object#completions/object-object
             created: common::current_timestamp().as_secs() as i64,
             model: model_id,
-            detections: Some(OpenAiDetections {
-                input: vec![InputDetectionResult {
+            detections: Some(CompletionDetections {
+                input: vec![CompletionInputDetections {
                     message_index: 0,
                     results: detections.into(),
                 }],
                 ..Default::default()
             }),
-            warnings: vec![OrchestratorWarning::new(
+            warnings: vec![CompletionDetectionWarning::new(
                 DetectionWarningReason::UnsuitableInput,
                 UNSUITABLE_INPUT_MESSAGE,
             )],
@@ -171,7 +171,7 @@ async fn handle_output_detection(
     let mut tasks = Vec::with_capacity(completion.choices.len());
     for choice in &completion.choices {
         if choice.text.is_empty() {
-            completion.warnings.push(OrchestratorWarning::new(
+            completion.warnings.push(CompletionDetectionWarning::new(
                 DetectionWarningReason::EmptyOutput,
                 &format!(
                     "Choice of index {} has no content. Output detection was not executed",
@@ -202,17 +202,17 @@ async fn handle_output_detection(
         let output = detections
             .into_iter()
             .filter(|(_, detections)| !detections.is_empty())
-            .map(|(input_id, detections)| OutputDetectionResult {
+            .map(|(input_id, detections)| CompletionOutputDetections {
                 choice_index: input_id,
                 results: detections.into(),
             })
             .collect::<Vec<_>>();
         if !output.is_empty() {
-            completion.detections = Some(OpenAiDetections {
+            completion.detections = Some(CompletionDetections {
                 output,
                 ..Default::default()
             });
-            completion.warnings = vec![OrchestratorWarning::new(
+            completion.warnings = vec![CompletionDetectionWarning::new(
                 DetectionWarningReason::UnsuitableOutput,
                 UNSUITABLE_OUTPUT_MESSAGE,
             )];

--- a/tests/chat_completions_streaming.rs
+++ b/tests/chat_completions_streaming.rs
@@ -5,8 +5,9 @@ use fms_guardrails_orchestr8::{
         detector::{ContentAnalysisRequest, ContentAnalysisResponse},
         openai::{
             ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionDelta,
-            ChatCompletionLogprob, ChatCompletionLogprobs, Content, InputDetectionResult, Message,
-            OpenAiDetections, OpenAiError, OpenAiErrorMessage, OutputDetectionResult, Role, Usage,
+            ChatCompletionLogprob, ChatCompletionLogprobs, CompletionDetections,
+            CompletionInputDetections, CompletionOutputDetections, Content, Message, OpenAiError,
+            OpenAiErrorMessage, Role, Usage,
         },
     },
     models::DetectorParams,
@@ -411,8 +412,8 @@ async fn input_detectors() -> Result<(), anyhow::Error> {
     // Validate input detections
     assert_eq!(
         messages[0].detections,
-        Some(OpenAiDetections {
-            input: vec![InputDetectionResult {
+        Some(CompletionDetections {
+            input: vec![CompletionInputDetections {
                 message_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 35,
@@ -821,9 +822,9 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
     // Validate msg-0 detections
     assert_eq!(
         messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![],
             }],
@@ -849,9 +850,9 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
     // Validate msg-2 detections
     assert_eq!(
         messages[1].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 5,
@@ -886,9 +887,9 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
     // Validate msg-2 detections
     assert_eq!(
         messages[2].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 4,
@@ -1448,9 +1449,9 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
     // Validate msg-0 detections
     assert_eq!(
         messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![],
             }],
@@ -1485,9 +1486,9 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
     // Validate msg-1 detections
     assert_eq!(
         messages[1].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 5,
@@ -1531,9 +1532,9 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
     // Validate msg-2 detections
     assert_eq!(
         messages[2].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 4,
@@ -1967,9 +1968,9 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
     // Validate msg-0 detections
     assert_eq!(
         messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![],
             }],
@@ -1995,9 +1996,9 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
     // Validate msg-2 detections
     assert_eq!(
         messages[1].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 5,
@@ -2032,9 +2033,9 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
     // Validate msg-2 detections
     assert_eq!(
         messages[2].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 4,
@@ -2554,9 +2555,9 @@ async fn output_detectors_with_continuous_usage_stats() -> Result<(), anyhow::Er
     // Validate msg-0 detections
     assert_eq!(
         messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![],
             }],
@@ -2593,9 +2594,9 @@ async fn output_detectors_with_continuous_usage_stats() -> Result<(), anyhow::Er
     // Validate msg-2 detections
     assert_eq!(
         messages[1].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 5,
@@ -2641,9 +2642,9 @@ async fn output_detectors_with_continuous_usage_stats() -> Result<(), anyhow::Er
     // Validate msg-2 detections
     assert_eq!(
         messages[2].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 4,
@@ -3399,9 +3400,9 @@ async fn output_detectors_n2() -> Result<(), anyhow::Error> {
     // Validate msg-0 detections
     assert_eq!(
         choice0_messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![],
             }],
@@ -3441,9 +3442,9 @@ async fn output_detectors_n2() -> Result<(), anyhow::Error> {
     // Validate msg-0 detections
     assert_eq!(
         choice1_messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 1,
                 results: vec![],
             }],
@@ -3735,9 +3736,9 @@ async fn whole_doc_output_detectors() -> Result<(), anyhow::Error> {
     let last = &messages[12];
     assert_eq!(
         last.detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![
                     ContentAnalysisResponse {
@@ -4196,9 +4197,9 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
     // Validate msg-0 detections
     assert_eq!(
         messages[0].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![],
             }],
@@ -4224,9 +4225,9 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
     // Validate msg-2 detections
     assert_eq!(
         messages[1].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 5,
@@ -4261,9 +4262,9 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
     // Validate msg-2 detections
     assert_eq!(
         messages[2].detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![ContentAnalysisResponse {
                     start: 4,
@@ -4291,9 +4292,9 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
     let last = &messages[4];
     assert_eq!(
         last.detections,
-        Some(OpenAiDetections {
+        Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![
                     ContentAnalysisResponse {

--- a/tests/chat_completions_unary.rs
+++ b/tests/chat_completions_unary.rs
@@ -34,9 +34,9 @@ use fms_guardrails_orchestr8::{
         chunker::MODEL_ID_HEADER_NAME as CHUNKER_MODEL_ID_HEADER_NAME,
         detector::{ContentAnalysisRequest, ContentAnalysisResponse},
         openai::{
-            ChatCompletion, ChatCompletionChoice, ChatCompletionMessage, Content, ContentPart,
-            ContentType, InputDetectionResult, Message, OpenAiDetections, OrchestratorWarning,
-            OutputDetectionResult, Role,
+            ChatCompletion, ChatCompletionChoice, ChatCompletionMessage,
+            CompletionDetectionWarning, CompletionDetections, CompletionInputDetections,
+            CompletionOutputDetections, Content, ContentPart, ContentType, Message, Role,
         },
     },
     models::{
@@ -413,11 +413,11 @@ async fn no_detections() -> Result<(), anyhow::Error> {
     ];
 
     let expected_warnings = vec![
-        OrchestratorWarning::new(
+        CompletionDetectionWarning::new(
             DetectionWarningReason::EmptyOutput,
             "Choice of index 0 has no content. Output detection was not executed",
         ),
-        OrchestratorWarning::new(
+        CompletionDetectionWarning::new(
             DetectionWarningReason::EmptyOutput,
             "Choice of index 1 has no content. Output detection was not executed",
         ),
@@ -495,14 +495,14 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     let chat_completions_response = ChatCompletion {
         model: MODEL_ID.into(),
         choices: vec![],
-        detections: Some(OpenAiDetections {
-            input: vec![InputDetectionResult {
+        detections: Some(CompletionDetections {
+            input: vec![CompletionInputDetections {
                 message_index: 0,
                 results: expected_detections.clone(),
             }],
             output: vec![],
         }),
-        warnings: vec![OrchestratorWarning::new(
+        warnings: vec![CompletionDetectionWarning::new(
             DetectionWarningReason::UnsuitableInput,
             UNSUITABLE_INPUT_MESSAGE,
         )],
@@ -849,14 +849,14 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     let chat_completions_response = ChatCompletion {
         model: MODEL_ID.into(),
         choices: expected_choices.clone(),
-        detections: Some(OpenAiDetections {
+        detections: Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 1,
                 results: expected_detections.clone(),
             }],
         }),
-        warnings: vec![OrchestratorWarning::new(
+        warnings: vec![CompletionDetectionWarning::new(
             DetectionWarningReason::UnsuitableOutput,
             UNSUITABLE_OUTPUT_MESSAGE,
         )],

--- a/tests/completions_detection.rs
+++ b/tests/completions_detection.rs
@@ -27,8 +27,8 @@ use fms_guardrails_orchestr8::{
         chunker::MODEL_ID_HEADER_NAME as CHUNKER_MODEL_ID_HEADER_NAME,
         detector::{ContentAnalysisRequest, ContentAnalysisResponse},
         openai::{
-            Completion, CompletionChoice, InputDetectionResult, OpenAiDetections,
-            OrchestratorWarning, OutputDetectionResult, TokenizeResponse, Usage,
+            Completion, CompletionChoice, CompletionDetectionWarning, CompletionDetections,
+            CompletionInputDetections, CompletionOutputDetections, TokenizeResponse, Usage,
         },
     },
     models::{
@@ -318,11 +318,11 @@ async fn no_detections() -> Result<(), anyhow::Error> {
         },
     ];
     let expected_warnings = vec![
-        OrchestratorWarning::new(
+        CompletionDetectionWarning::new(
             DetectionWarningReason::EmptyOutput,
             "Choice of index 0 has no content. Output detection was not executed",
         ),
-        OrchestratorWarning::new(
+        CompletionDetectionWarning::new(
             DetectionWarningReason::EmptyOutput,
             "Choice of index 1 has no content. Output detection was not executed",
         ),
@@ -405,14 +405,14 @@ async fn input_detections() -> Result<(), anyhow::Error> {
         created: current_timestamp().as_secs() as i64,
         model: MODEL_ID.into(),
         choices: vec![],
-        detections: Some(OpenAiDetections {
-            input: vec![InputDetectionResult {
+        detections: Some(CompletionDetections {
+            input: vec![CompletionInputDetections {
                 message_index: 0,
                 results: expected_detections.clone(),
             }],
             output: vec![],
         }),
-        warnings: vec![OrchestratorWarning::new(
+        warnings: vec![CompletionDetectionWarning::new(
             DetectionWarningReason::UnsuitableInput,
             UNSUITABLE_INPUT_MESSAGE,
         )],
@@ -731,14 +731,14 @@ async fn output_detections() -> Result<(), anyhow::Error> {
         created: current_timestamp().as_secs() as i64,
         model: MODEL_ID.into(),
         choices: expected_choices,
-        detections: Some(OpenAiDetections {
+        detections: Some(CompletionDetections {
             input: vec![],
-            output: vec![OutputDetectionResult {
+            output: vec![CompletionOutputDetections {
                 choice_index: 1,
                 results: expected_detections.clone(),
             }],
         }),
-        warnings: vec![OrchestratorWarning::new(
+        warnings: vec![CompletionDetectionWarning::new(
             DetectionWarningReason::UnsuitableOutput,
             UNSUITABLE_OUTPUT_MESSAGE,
         )],


### PR DESCRIPTION
nit: this PR renames detection types common to completions and chat completions for alignment. We are now using "completion" naming for common types. Also assigns better names to associated types.

`OpenAiDetections` -> `CompletionDetections` (this type is for completions/chat completions detections specifically)
`InputDetectionResult` -> `CompletionInputDetections`
`OutputDetectionResult` -> `CompletionOutputDetections`
`OrchestratorWarning` -> `CompletionDetectionWarning`