### PR TITLE
:construction_worker: Update builder layer to use UBI 9 minimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -324,9 +324,9 @@ checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cc"
-version = "1.2.28"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -632,7 +632,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project-lite",
  "prost",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest",
  "rustls",
  "rustls-pemfile",
@@ -1021,7 +1021,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64",
  "bytes",
@@ -1071,7 +1071,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1213,7 +1213,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1445,7 +1445,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "prost",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1639,7 +1639,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
@@ -1847,7 +1847,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -1863,7 +1863,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -1884,7 +1884,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -1965,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags",
 ]
@@ -2061,7 +2061,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -2104,7 +2104,7 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand 0.9.1",
+ "rand 0.9.2",
  "thiserror 2.0.12",
 ]
 
@@ -2141,15 +2141,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2391,6 +2391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,7 +2479,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -2615,7 +2625,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -2697,7 +2707,7 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2914,7 +2924,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
- "rand 0.9.1",
+ "rand 0.9.2",
  "wasm-bindgen",
 ]
 
@@ -3070,14 +3080,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -15,13 +15,16 @@ RUN microdnf -y update && \
         unzip \
         ca-certificates \
         openssl-devel \
-        pkgconf-pkg-config \
-        gcc \
-        glibc-devel && \
+        gcc && \
     microdnf clean all
 
+COPY rust-toolchain.toml rust-toolchain.toml
+
 # Install rustup [needed for latest Rust versions]
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y --no-modify-path && \
+    . "$HOME/.cargo/env" && \
+    rustup install && \
+    rustup component add rustfmt
 
 # Set PATH so rustc, cargo, rustup are available
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -33,10 +36,6 @@ RUN cd /tmp && \
 ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib/
 
 WORKDIR /app
-
-COPY rust-toolchain.toml rust-toolchain.toml
-
-RUN rustup component add rustfmt
 
 ## Orchestrator builder #########################################################
 FROM rust-builder AS fms-guardrails-orchestr8-builder

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -10,8 +10,8 @@ ARG PROTOC_VERSION
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Install dependencies
-RUN microdnf -y update && \
-    microdnf install -y \
+RUN microdnf --disableplugin=subscription-manager -y update && \
+    microdnf install --disableplugin=subscription-manager -y \
         unzip \
         ca-certificates \
         openssl-devel \

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,11 +4,27 @@ ARG PROTOC_VERSION=29.3
 ARG CONFIG_FILE=config/config.yaml
 
 ## Rust builder ################################################################
-# Specific debian version so that compatible glibc version is used
-FROM rust:1 AS rust-builder
+FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS rust-builder
 ARG PROTOC_VERSION
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+# Install dependencies
+RUN microdnf -y update && \
+    microdnf install -y \
+        unzip \
+        ca-certificates \
+        openssl-devel \
+        pkgconf-pkg-config \
+        gcc \
+        glibc-devel && \
+    microdnf clean all
+
+# Install rustup [needed for latest Rust versions]
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
+
+# Set PATH so rustc, cargo, rustup are available
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install protoc, no longer included in prost crate
 RUN cd /tmp && \

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -4,16 +4,36 @@ ARG PROTOC_VERSION=29.3
 ARG CONFIG_FILE=config/config.yaml
 
 ## Rust builder ################################################################
-# Specific debian version so that compatible glibc version is used
-FROM rust:1 AS rust-builder
+FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS rust-builder
 ARG PROTOC_VERSION
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
+# Install dependencies
+RUN microdnf -y update && \
+    microdnf install -y \
+        unzip \
+        ca-certificates \
+        openssl-devel \
+        gcc \
+        cmake \
+        clang \
+        clang-devel && \
+    microdnf clean all
+
+COPY rust-toolchain.toml rust-toolchain.toml
+
+# Install rustup [needed for latest Rust versions]
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y --no-modify-path && \
+    . "$HOME/.cargo/env" && \
+    rustup install && \
+    rustup component add rustfmt
+
+# Set PATH so rustc, cargo, rustup are available
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Install protoc, no longer included in prost crate
 RUN cd /tmp && \
-    apt update && \
-    apt install -y cmake libclang-dev && \
     curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-ppcle_64.zip; \
     unzip protoc-*.zip -d /usr/local && \
     rm protoc-*.zip

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -10,8 +10,8 @@ ARG PROTOC_VERSION
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Install dependencies
-RUN microdnf -y update && \
-    microdnf install -y \
+RUN microdnf --disableplugin=subscription-manager -y update && \
+    microdnf install --disableplugin=subscription-manager -y \
         unzip \
         ca-certificates \
         openssl-devel \

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -4,24 +4,41 @@ ARG PROTOC_VERSION=29.3
 ARG CONFIG_FILE=config/config.yaml
 
 ## Rust builder ################################################################
-# Specific debian version so that compatible glibc version is used
-FROM rust:1 AS rust-builder
+FROM ${UBI_MINIMAL_BASE_IMAGE}:${UBI_BASE_IMAGE_TAG} AS rust-builder
 ARG PROTOC_VERSION
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+# Install dependencies
+RUN microdnf -y update && \
+    microdnf install -y \
+        unzip \
+        ca-certificates \
+        openssl-devel \
+        gcc \
+        cmake \
+        clang \
+        clang-devel && \
+    microdnf clean all
+
+COPY rust-toolchain.toml rust-toolchain.toml
+
+# Install rustup [needed for latest Rust versions]
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y --no-modify-path && \
+    . "$HOME/.cargo/env" && \
+    rustup install && \
+    rustup component add rustfmt
+
+# Set PATH so rustc, cargo, rustup are available
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install protoc, no longer included in prost crate
 RUN cd /tmp && \
     curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-s390_64.zip && \
     unzip protoc-*.zip -d /usr/local && rm protoc-*.zip
-RUN apt update && apt install -y cmake clang libclang-dev
 ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib/
 
 WORKDIR /app
-
-COPY rust-toolchain.toml rust-toolchain.toml
-
-RUN rustup component add rustfmt
 
 ## Orchestrator builder #########################################################
 FROM rust-builder AS fms-guardrails-orchestr8-builder

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -10,8 +10,8 @@ ARG PROTOC_VERSION
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 # Install dependencies
-RUN microdnf -y update && \
-    microdnf install -y \
+RUN microdnf --disableplugin=subscription-manager -y update && \
+    microdnf install --disableplugin=subscription-manager -y \
         unzip \
         ca-certificates \
         openssl-devel \


### PR DESCRIPTION
For image provenance purposes, we have been asked to leverage Red Hat registry images for the builder layer as well as the release layer - here we leverage UBI 9 minimal. The latest RHEL (9.6) uses `1.84.1` Rust and Cargo, so we still install `rustup` via `curl` to leverage the latest versions (1.88 currently).

The existing Rust toolchain from `rust-toolchain.toml` is leveraged.

`amd64` has been tested with this PR but all architectures have been updated to enable Red Hat image building. Other architectures may have to be tested/debugged by other individuals or teams with access.