### PR TITLE
fix: OpenTelemetry exporter fails with HTTP protocol

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,10 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use clap::Parser;
 use fms_guardrails_orchestr8::{
-    args::Args, config::OrchestratorConfig, orchestrator::Orchestrator, server, utils,
+    args::{Args, TracingConfig},
+    config::OrchestratorConfig,
+    orchestrator::Orchestrator,
+    server, utils,
 };
 use tracing::info;
 
@@ -47,7 +50,8 @@ fn main() -> Result<(), anyhow::Error> {
         .build()
         .unwrap()
         .block_on(async {
-            let trace_shutdown = utils::trace::init_tracing(args.clone().into())?;
+            let tracing_config: TracingConfig = args.clone().try_into()?;
+            let trace_shutdown = utils::trace::init_tracing(tracing_config)?;
             let config = OrchestratorConfig::load(args.config_path).await?;
             let orchestrator = Orchestrator::new(config, args.start_up_health_check).await?;
 

--- a/src/utils/trace.rs
+++ b/src/utils/trace.rs
@@ -40,6 +40,9 @@ use crate::{
     clients::http::TracedResponse,
 };
 
+pub const DEFAULT_GRPC_OTLP_ENDPOINT: &str = "http://localhost:4317";
+pub const DEFAULT_HTTP_OTLP_ENDPOINT: &str = "http://localhost:4318";
+
 fn resource(tracing_config: TracingConfig) -> Resource {
     Resource::builder()
         .with_service_name(tracing_config.service_name)

--- a/src/utils/trace.rs
+++ b/src/utils/trace.rs
@@ -188,31 +188,21 @@ pub fn init_tracing(
     let subscriber = tracing_subscriber::registry().with(filter).with(layers);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    if let Some(traces) = tracing_config.traces {
-        info!(
-            "OTLP tracing enabled: Exporting {} to {}",
-            traces.0, traces.1
-        );
+    if let Some((protocol, endpoint)) = tracing_config.traces {
+        info!(%protocol, %endpoint, "OTLP traces enabled");
     } else {
-        info!("OTLP traces export disabled")
+        info!("OTLP traces disabled")
     }
-
-    if let Some(metrics) = tracing_config.metrics {
-        info!(
-            "OTLP metrics enabled: Exporting {} to {}",
-            metrics.0, metrics.1
-        );
+    if let Some((protocol, endpoint)) = tracing_config.metrics {
+        info!(%protocol, %endpoint, "OTLP metrics enabled");
     } else {
-        info!("OTLP metrics export disabled")
+        info!("OTLP metrics disabled")
     }
 
     if !tracing_config.quiet {
-        info!(
-            "Stdout logging enabled with format {}",
-            tracing_config.log_format
-        );
+        info!(format = %tracing_config.log_format, "stdout logging enabled");
     } else {
-        info!("Stdout logging disabled"); // This will only be visible in traces
+        info!("stdout logging disabled"); // This will only be visible in traces
     }
 
     Ok(move || {

--- a/src/utils/trace.rs
+++ b/src/utils/trace.rs
@@ -24,7 +24,7 @@ use opentelemetry::{
     trace::{TraceContextExt, TraceId, TracerProvider},
 };
 use opentelemetry_http::{HeaderExtractor, HeaderInjector};
-use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
     Resource,
     metrics::{PeriodicReader, SdkMeterProvider},
@@ -62,7 +62,6 @@ fn init_tracer_provider(
                 .context("Failed to build gRPC span exporter")?,
             OtlpProtocol::Http => SpanExporter::builder()
                 .with_http()
-                .with_http_client(reqwest::Client::new())
                 .with_endpoint(endpoint)
                 .with_timeout(timeout)
                 .build()
@@ -107,7 +106,6 @@ fn init_meter_provider(
                 .context("Failed to build OTel gRPC metric exporter")?,
             OtlpProtocol::Http => MetricExporter::builder()
                 .with_http()
-                .with_http_client(reqwest::Client::new())
                 .with_endpoint(endpoint)
                 .with_timeout(timeout)
                 .build()


### PR DESCRIPTION
This PR resolves a bug when using the OpenTelemetry exporter with the HTTP protocol, resulting in the following errors:
```
thread 'OpenTelemetry.Metrics.PeriodicReader' panicked at /Users/dan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.16/src/client/legacy/connect/dns.rs:119:24:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'OpenTelemetry.Traces.BatchProcessor' panicked at /Users/dan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.16/src/client/legacy/connect/dns.rs:119:24:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

The async runtime requirements were dropped from `opentelemetry-rust` in 0.28 as explained in the migration guide [here](https://github.com/open-telemetry/opentelemetry-rust/blob/main/docs/migration_0.28.md#async-runtime-requirements-removed), in favor of running the exporters in a dedicated thread with blocking clients.

Our code attempted to use `reqwest::Client` as the HTTP client, which is async, from a non-async context. This PR updates the `MetricsExporter` and `SpanExporter` builders to default to `reqwest-blocking-client` when using the HTTP protocol.

Additional related changes:
- Use `Url` instead of `String` for endpoint arguments
- Replace `From<Args> for TracingConfig` implementation with `TryFrom`, including protocol-specific validation for the provided endpoints and revised logic for setting defaults for traces and metrics endpoints
  - The existing logic wasn't sufficient as metrics and traces have different endpoints for HTTP, defaults vary by protocol, and it lacked validation
- Tweaked `init_tracing` log messages

Tested locally using a jaeger container, e.g.
```
docker run --rm --name jaeger -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 -e COLLECTOR_OTLP_ENABLED=true -p 6831:6831/udp -p 6832:6832/udp -p 5778:5778 -p 16686:16686 -p 4317:4317 -p 4318:4318 -p 14250:14250 -p 14268:14268 -p 14269:14269 -p 9411:9411 jaegertracing/all-in-one:1.54

# With HTTP exporter
target/debug/fms-guardrails-orchestr8 --config-path config.yaml --otlp-endpoint http://localhost:4318 --otlp-export traces,metrics --otlp-protocol http

# With gRPC exporter (default)
target/debug/fms-guardrails-orchestr8 --config-path config.yaml --otlp-endpoint http://localhost:4317 --otlp-export traces,metrics
```

Closes #464