### PR TITLE
Add prompt masks for completions input detection

### DIFF
--- a/src/clients/openai.rs
+++ b/src/clients/openai.rs
@@ -346,6 +346,10 @@ pub struct CompletionsRequest {
     /// Detector config.
     #[serde(default, skip_serializing)]
     pub detectors: DetectorConfig,
+    /// Prompt masks.
+    #[serde(rename = "_prompt_masks", skip_serializing)]
+    #[doc(hidden)]
+    pub prompt_masks: Option<Vec<(usize, usize)>>,
     /// Stream parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,

--- a/src/orchestrator/handlers/completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/completions_detection/streaming.rs
@@ -140,15 +140,16 @@ async fn handle_input_detection(
 ) -> Result<Option<Completion>, Error> {
     let trace_id = task.trace_id;
     let model_id = task.request.model.clone();
-
-    let input_id = 0;
-    let input_text = task.request.prompt.clone();
+    let inputs = common::apply_masks(
+        task.request.prompt.clone(),
+        task.request.prompt_masks.as_deref(),
+    );
     let detections = match common::text_contents_detections(
         ctx.clone(),
         task.headers.clone(),
         detectors.clone(),
-        input_id,
-        vec![(0, input_text)],
+        0,
+        inputs,
     )
     .await
     {
@@ -180,7 +181,7 @@ async fn handle_input_detection(
             created: common::current_timestamp().as_secs() as i64,
             detections: Some(CompletionDetections {
                 input: vec![CompletionInputDetections {
-                    message_index: input_id,
+                    message_index: 0,
                     results: detections.into(),
                 }],
                 ..Default::default()

--- a/src/orchestrator/handlers/completions_detection/unary.rs
+++ b/src/orchestrator/handlers/completions_detection/unary.rs
@@ -95,14 +95,16 @@ async fn handle_input_detection(
 ) -> Result<Option<Completion>, Error> {
     let trace_id = task.trace_id;
     let model_id = task.request.model.clone();
-
-    let input_text = task.request.prompt.clone();
+    let inputs = common::apply_masks(
+        task.request.prompt.clone(),
+        task.request.prompt_masks.as_deref(),
+    );
     let detections = match common::text_contents_detections(
         ctx.clone(),
         task.headers.clone(),
         detectors.clone(),
         0,
-        vec![(0, input_text)],
+        inputs,
     )
     .await
     {


### PR DESCRIPTION
This PR adds a `prompt_masks` field to `CompletionsRequest` (provided by user as `_prompt_masks`) and updates completions input detection handlers to apply masks. This is a "hidden" feature to maintain parity with `guardrail_config.input.masks` from classification-with-text-generation.

e.g.  the following will only detect the first phone number
```json
{
	"model": "example-0b",
	"prompt": "my home phone number is 312-111-1122 and my cell phone number is 312-555-1423.",
	"detectors": {
		"input": {
			"pii": {}
		}
	},
	"_prompt_masks": [[0, 37]]
}
```
Unrelated change (nit): dropped `let input_id = 0;` for consistency between unary and streaming handlers

NOTE: In Rust, leading underscores on field and variable names means "unused" rather than "internal" as in Python and they have special handling for linting purposes, which is why I named the field `prompt_masks` with a serde rename to `_prompt_masks`. I added `#[doc(hidden)]` which hides the field from documentation.

Closes #467