### PR TITLE
Fix build failure for ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -38,7 +38,7 @@ RUN cd /tmp && \
     unzip protoc-*.zip -d /usr/local && \
     rm protoc-*.zip
 
-ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib/
+ENV LIBCLANG_PATH=/usr/lib64/
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR resolves a build failure when building the image for the `ppc64le` architecture. The failure is caused by the inability to locate the `libclang` library during the build process.

error:
```
Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the LIBCLANG_PAT
H environment variable to a path where one of these files can be found (invalid: [])"
```

The issue is fixed by updating the `LIBCLANG_PATH` environment variable to the appropriate location.