### PR TITLE
Update ClientMap get methods

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -148,27 +148,15 @@ impl ClientMap {
         self.0.insert(key, Box::new(value));
     }
 
-    /// Returns a reference to the client trait object.
+    /// Returns a reference to the concrete client type.
     #[inline]
-    pub fn get(&self, key: &str) -> Option<&dyn Client> {
-        self.0.get(key).map(|v| v.as_ref())
-    }
-
-    /// Returns a mutable reference to the client trait object.
-    #[inline]
-    pub fn get_mut(&mut self, key: &str) -> Option<&mut dyn Client> {
-        self.0.get_mut(key).map(|v| v.as_mut())
-    }
-
-    /// Downcasts and returns a reference to the concrete client type.
-    #[inline]
-    pub fn get_as<V: Client>(&self, key: &str) -> Option<&V> {
+    pub fn get<V: Client>(&self, key: &str) -> Option<&V> {
         self.0.get(key)?.downcast_ref::<V>()
     }
 
-    /// Downcasts and returns a mutable reference to the concrete client type.
+    /// Returns a mutable reference to the concrete client type.
     #[inline]
-    pub fn get_mut_as<V: Client>(&mut self, key: &str) -> Option<&mut V> {
+    pub fn get_mut<V: Client>(&mut self, key: &str) -> Option<&mut V> {
         self.0.get_mut(key)?.downcast_mut::<V>()
     }
 

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -65,7 +65,7 @@ pub async fn chunks(
                                 }
                                 let client = ctx
                                     .clients
-                                    .get_as::<ChunkerClient>(&chunker_id)
+                                    .get::<ChunkerClient>(&chunker_id)
                                     .ok_or_else(|| Error::ChunkerNotFound(chunker_id.clone()))?;
                                 let chunks = chunk(client, chunker_id.clone(), text)
                                     .await?
@@ -123,7 +123,7 @@ pub async fn chunk_streams(
         } else {
             let client = ctx
                 .clients
-                .get_as::<ChunkerClient>(&chunker_id)
+                .get::<ChunkerClient>(&chunker_id)
                 .ok_or_else(|| Error::ChunkerNotFound(chunker_id.clone()))?;
             chunk_stream(client, chunker_id.clone(), input_broadcast_rx).await
         }?;
@@ -210,7 +210,7 @@ pub async fn text_contents_detections(
             let default_threshold = ctx.config.detector(&detector_id).unwrap().default_threshold;
             let threshold = params.pop_threshold().unwrap_or(default_threshold);
             async move {
-                let client = ctx.clients.get_as::<DetectorClient>(&detector_id).unwrap();
+                let client = ctx.clients.get::<DetectorClient>(&detector_id).unwrap();
                 let detections = detect_text_contents(
                     client,
                     headers,
@@ -266,8 +266,7 @@ pub async fn text_contents_detection_streams(
                 while let Ok(result) = chunk_rx.recv().await {
                     match result {
                         Ok(chunk) => {
-                            let client =
-                                ctx.clients.get_as::<DetectorClient>(&detector_id).unwrap();
+                            let client = ctx.clients.get::<DetectorClient>(&detector_id).unwrap();
                             match detect_text_contents(
                                 client,
                                 headers.clone(),
@@ -338,7 +337,7 @@ pub async fn text_generation_detections(
             let default_threshold = ctx.config.detector(&detector_id).unwrap().default_threshold;
             let threshold = params.pop_threshold().unwrap_or(default_threshold);
             async move {
-                let client = ctx.clients.get_as::<DetectorClient>(&detector_id).unwrap();
+                let client = ctx.clients.get::<DetectorClient>(&detector_id).unwrap();
                 let detections = detect_text_generation(
                     client,
                     headers,
@@ -391,7 +390,7 @@ pub async fn text_chat_detections(
             let default_threshold = ctx.config.detector(&detector_id).unwrap().default_threshold;
             let threshold = params.pop_threshold().unwrap_or(default_threshold);
             async move {
-                let client = ctx.clients.get_as::<DetectorClient>(&detector_id).unwrap();
+                let client = ctx.clients.get::<DetectorClient>(&detector_id).unwrap();
                 let detections = detect_text_chat(
                     client,
                     headers,
@@ -448,7 +447,7 @@ pub async fn text_context_detections(
                     ctx.config.detector(&detector_id).unwrap().default_threshold;
                 let threshold = params.pop_threshold().unwrap_or(default_threshold);
                 async move {
-                    let client = ctx.clients.get_as::<DetectorClient>(&detector_id).unwrap();
+                    let client = ctx.clients.get::<DetectorClient>(&detector_id).unwrap();
                     let detections = detect_text_context(
                         client,
                         headers,

--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -94,7 +94,7 @@ pub async fn handle_streaming(
             // Create chat completions stream
             let client = ctx
                 .clients
-                .get_as::<OpenAiClient>("openai")
+                .get::<OpenAiClient>("openai")
                 .unwrap();
             let chat_completion_stream = match common::chat_completion_stream(client, task.headers.clone(), task.request.clone()).await {
                 Ok(stream) => stream,
@@ -178,7 +178,7 @@ async fn handle_input_detection(
     };
     if !detections.is_empty() {
         // Get prompt tokens for usage
-        let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
+        let client = ctx.clients.get::<OpenAiClient>("openai").unwrap();
         let tokenize_request = TokenizeRequest {
             model: model_id.clone(),
             prompt: Some(input_text),

--- a/src/orchestrator/handlers/chat_completions_detection/unary.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/unary.rs
@@ -69,7 +69,7 @@ pub async fn handle_unary(
     }
 
     // Handle chat completion
-    let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
+    let client = ctx.clients.get::<OpenAiClient>("openai").unwrap();
     let chat_completion =
         match common::chat_completion(client, task.headers.clone(), task.request.clone()).await {
             Ok(ChatCompletionsResponse::Unary(chat_completion)) => *chat_completion,
@@ -135,7 +135,7 @@ async fn handle_input_detection(
     };
     if !detections.is_empty() {
         // Get prompt tokens for usage
-        let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
+        let client = ctx.clients.get::<OpenAiClient>("openai").unwrap();
         let tokenize_request = TokenizeRequest {
             model: model_id.clone(),
             prompt: Some(input_text),

--- a/src/orchestrator/handlers/classification_with_gen.rs
+++ b/src/orchestrator/handlers/classification_with_gen.rs
@@ -75,10 +75,7 @@ impl Handle<ClassificationWithGenTask> for Orchestrator {
         }
 
         // Handle generation
-        let client = ctx
-            .clients
-            .get_as::<GenerationClient>("generation")
-            .unwrap();
+        let client = ctx.clients.get::<GenerationClient>("generation").unwrap();
         let generation = common::generate(
             client,
             task.headers.clone(),
@@ -124,10 +121,7 @@ async fn handle_input_detection(
     };
     if !detections.is_empty() {
         // Get token count
-        let client = ctx
-            .clients
-            .get_as::<GenerationClient>("generation")
-            .unwrap();
+        let client = ctx.clients.get::<GenerationClient>("generation").unwrap();
         let input_token_count = match common::tokenize(
             client,
             task.headers.clone(),

--- a/src/orchestrator/handlers/completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/completions_detection/streaming.rs
@@ -93,7 +93,7 @@ pub async fn handle_streaming(
             // Create completions stream
             let client = ctx
                 .clients
-                .get_as::<OpenAiClient>("openai")
+                .get::<OpenAiClient>("openai")
                 .unwrap();
             let completion_stream = match common::completion_stream(client, task.headers.clone(), task.request.clone()).await {
                 Ok(stream) => stream,
@@ -161,7 +161,7 @@ async fn handle_input_detection(
     };
     if !detections.is_empty() {
         // Get prompt tokens for usage
-        let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
+        let client = ctx.clients.get::<OpenAiClient>("openai").unwrap();
         let tokenize_request = TokenizeRequest {
             model: model_id.clone(),
             prompt: Some(task.request.prompt.clone()),

--- a/src/orchestrator/handlers/completions_detection/unary.rs
+++ b/src/orchestrator/handlers/completions_detection/unary.rs
@@ -68,7 +68,7 @@ pub async fn handle_unary(
     }
 
     // Handle completion
-    let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
+    let client = ctx.clients.get::<OpenAiClient>("openai").unwrap();
     let completion =
         match common::completion(client, task.headers.clone(), task.request.clone()).await {
             Ok(CompletionsResponse::Unary(completion)) => *completion,
@@ -116,7 +116,7 @@ async fn handle_input_detection(
     };
     if !detections.is_empty() {
         // Get prompt tokens for usage
-        let client = ctx.clients.get_as::<OpenAiClient>("openai").unwrap();
+        let client = ctx.clients.get::<OpenAiClient>("openai").unwrap();
         let tokenize_request = TokenizeRequest {
             model: model_id.clone(),
             prompt: Some(task.request.prompt.clone()),

--- a/src/orchestrator/handlers/generation_with_detection.rs
+++ b/src/orchestrator/handlers/generation_with_detection.rs
@@ -55,10 +55,7 @@ impl Handle<GenerationWithDetectionTask> for Orchestrator {
         )?;
 
         // Handle generation
-        let client = ctx
-            .clients
-            .get_as::<GenerationClient>("generation")
-            .unwrap();
+        let client = ctx.clients.get::<GenerationClient>("generation").unwrap();
         let generation = common::generate(
             client,
             task.headers.clone(),

--- a/src/orchestrator/handlers/streaming_classification_with_gen.rs
+++ b/src/orchestrator/handlers/streaming_classification_with_gen.rs
@@ -124,7 +124,7 @@ impl Handle<StreamingClassificationWithGenTask> for Orchestrator {
             // Create generation stream
             let client = ctx
                 .clients
-                .get_as::<GenerationClient>("generation")
+                .get::<GenerationClient>("generation")
                 .unwrap();
             let generation_stream = match common::generate_stream(
                 client,
@@ -189,10 +189,7 @@ async fn handle_input_detection(
     };
     if !detections.is_empty() {
         // Get token count
-        let client = ctx
-            .clients
-            .get_as::<GenerationClient>("generation")
-            .unwrap();
+        let client = ctx.clients.get::<GenerationClient>("generation").unwrap();
         let input_token_count = match common::tokenize(
             client,
             task.headers.clone(),


### PR DESCRIPTION
This is a small nit PR to tweak the `ClientMap` get methods. Initial `get` and `get_mut` methods returned `&dyn Client` (trait object) as I anticipated we would use `get` for client health checks. We ultimately didn't use it as we have an `iter` method that iterates over all client trait objects, which is more convenient for performing health checks. As such, we do not need to have a separate set of unidiomatic `get_as` and `get_mut_as` methods to return concrete client types.

Changes:
- Drop existing `get` and `get_mut` methods
- Rename `get_as` and `get_mut_as` to `get` and `get_mut`, respectively
- Update usage