### PR TITLE
Drop client health caching functionality

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -47,49 +47,6 @@ impl From<StatusCode> for HealthStatus {
             500..=599 => Self::Unhealthy,
             _ => Self::Unknown,
         }
-    }
-}
-
-/// A cache to hold the latest health check results for each client service.
-/// Orchestrator has a reference-counted mutex-protected instance of this cache.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct HealthCheckCache(HashMap<String, HealthCheckResult>);
-
-impl HealthCheckCache {
-    pub fn new() -> Self {
-        Self(HashMap::new())
-    }
-
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(HashMap::with_capacity(capacity))
-    }
-
-    /// Returns `true` if all services are healthy or unknown.
-    pub fn healthy(&self) -> bool {
-        !self
-            .0
-            .iter()
-            .any(|(_, value)| matches!(value.status, HealthStatus::Unhealthy))
-    }
-}
-
-impl std::ops::Deref for HealthCheckCache {
-    type Target = HashMap<String, HealthCheckResult>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for HealthCheckCache {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Display for HealthCheckCache {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string_pretty(self).unwrap())
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -27,7 +27,7 @@ use crate::{
         detector::{ContentAnalysisResponse, ContextType},
         openai::{Content, ContentType},
     },
-    health::HealthCheckCache,
+    health::HealthCheckResult,
     pb,
 };
 
@@ -35,7 +35,7 @@ pub const THRESHOLD_PARAM: &str = "threshold";
 
 #[derive(Clone, Debug, Serialize)]
 pub struct InfoResponse {
-    pub services: HealthCheckCache,
+    pub services: HashMap<String, HealthCheckResult>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -22,7 +22,7 @@ use std::{
 
 use axum::{
     Json, Router,
-    extract::{Query, State},
+    extract::State,
     http::HeaderMap,
     response::{
         IntoResponse, Response,
@@ -44,7 +44,7 @@ use crate::{
     clients::openai::{
         ChatCompletionsRequest, ChatCompletionsResponse, CompletionsRequest, CompletionsResponse,
     },
-    models::{self, InfoParams, InfoResponse, StreamingContentDetectionRequest},
+    models::{self, InfoResponse, StreamingContentDetectionRequest},
     orchestrator::{
         self,
         handlers::{
@@ -119,10 +119,7 @@ async fn health() -> Result<impl IntoResponse, ()> {
     Ok(Json(info_object).into_response())
 }
 
-async fn info(
-    State(state): State<Arc<ServerState>>,
-    Query(_params): Query<InfoParams>,
-) -> Result<Json<InfoResponse>, Error> {
+async fn info(State(state): State<Arc<ServerState>>) -> Result<Json<InfoResponse>, Error> {
     let services = state.orchestrator.client_health().await;
     Ok(Json(InfoResponse { services }))
 }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -121,9 +121,9 @@ async fn health() -> Result<impl IntoResponse, ()> {
 
 async fn info(
     State(state): State<Arc<ServerState>>,
-    Query(params): Query<InfoParams>,
+    Query(_params): Query<InfoParams>,
 ) -> Result<Json<InfoResponse>, Error> {
-    let services = state.orchestrator.client_health(params.probe).await;
+    let services = state.orchestrator.client_health().await;
     Ok(Json(InfoResponse { services }))
 }
 


### PR DESCRIPTION
This PR drops client health caching functionality as we determined it is not needed or used as initially intended. `/info` calls will now _always_ run client health probes (`probe=true` parameter is no longer required), returning the _current_ health status for all clients. Also tweaked a couple of logs and added in a warning log if any clients are unhealthy during startup probes. Tested locally and compared `/info` results with main to validate.

NOTE: I attempted to update `client_health()` to run client health checks concurrently, but I can't figure out how to work around a lifetime issue from the router related to having to use a reference to the client trait object (`&Box<dyn Client>`). I left the concurrent code commented out to further investigate. For now, the health checks will continue to run sequentially.