### PR TITLE
Preparation for release 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1071,7 +1071,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2154,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2612,9 +2612,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2625,9 +2625,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fms-guardrails-orchestr8"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1.88"
 axum = { version = "0.8.4", features = ["json"] }
 axum-extra = { version = "0.10.1", features = ["json-lines"] }
 bytes = "1.10.1"
-clap = { version = "4.5.41", features = ["derive", "env"] }
+clap = { version = "4.5.43", features = ["derive", "env"] }
 dashmap = "6.1.0"
 eventsource-stream = "0.2.3"
 futures = "0.3.31"
@@ -52,7 +52,7 @@ reqwest = { version = "0.12.22", features = [
     "json",
     "stream",
 ] }
-rustls = { version = "0.23.29", default-features = false, features = [
+rustls = { version = "0.23.31", default-features = false, features = [
     "ring",
     "std",
 ] }
@@ -60,10 +60,10 @@ rustls-pemfile = "2.2.0"
 rustls-pki-types = "1.12.0"
 rustls-webpki = "0.103.4"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = { version = "1.0.141", features = ["preserve_order"] }
+serde_json = { version = "1.0.142", features = ["preserve_order"] }
 serde_yml = "0.0.12"
 thiserror = "2.0.12"
-tokio = { version = "1.46.1", features = [
+tokio = { version = "1.47.1", features = [
     "rt",
     "rt-multi-thread",
     "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fms-guardrails-orchestr8"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Evaline Ju", "Gaurav Kumbhat", "Dan Clark"]
 description = "Foundation models orchestration server"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -194,10 +194,10 @@ impl TryFrom<Args> for TracingConfig {
         let otlp_metrics_protocol = args.otlp_metrics_protocol.unwrap_or(otlp_protocol);
 
         // Validate provided endpoints
-        if let Some(endpoint) = &args.otlp_endpoint {
-            if endpoint.path() != "/" {
-                return Err(ValidationError::Invalid("invalid otlp_endpoint".into()));
-            }
+        if let Some(endpoint) = &args.otlp_endpoint
+            && endpoint.path() != "/"
+        {
+            return Err(ValidationError::Invalid("invalid otlp_endpoint".into()));
         }
         if let Some(endpoint) = &args.otlp_traces_endpoint {
             match otlp_traces_protocol {

--- a/src/models.rs
+++ b/src/models.rs
@@ -125,12 +125,12 @@ impl GuardrailsHttpRequest {
         let input_range = 0..=self.inputs.len();
         let input_masks = guardrail_config
             .and_then(|config| config.input.as_ref().and_then(|input| input.masks.as_ref()));
-        if let Some(input_masks) = input_masks {
-            if !input_masks.iter().all(|(start, end)| {
+        if let Some(input_masks) = input_masks
+            && !input_masks.iter().all(|(start, end)| {
                 input_range.contains(start) && input_range.contains(end) && start < end
-            }) {
-                return Err(ValidationError::Invalid("invalid masks".into()));
-            }
+            })
+        {
+            return Err(ValidationError::Invalid("invalid masks".into()));
         }
 
         // Validate detector params
@@ -1136,12 +1136,12 @@ fn validate_detector_params(
 ) -> Result<(), ValidationError> {
     for (model_id, detector_params) in models {
         // Validate threshold is a number, if specified
-        if let Some(threshold) = detector_params.get("threshold") {
-            if !threshold.is_number() {
-                return Err(ValidationError::Invalid(format!(
-                    "`threshold` parameter specified for model `{model_id}` must be a number"
-                )));
-            }
+        if let Some(threshold) = detector_params.get("threshold")
+            && !threshold.is_number()
+        {
+            return Err(ValidationError::Invalid(format!(
+                "`threshold` parameter specified for model `{model_id}` must be a number"
+            )));
         }
     }
     Ok(())

--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -358,15 +358,14 @@ async fn process_chat_completion_stream(
                 // Send chat completion chunk to response channel
                 // NOTE: this forwards chat completion chunks without detections and is only
                 // done here for 2 cases: a) no output detectors b) only whole doc output detectors
-                if let Some(response_tx) = &response_tx {
-                    if response_tx
+                if let Some(response_tx) = &response_tx
+                    && response_tx
                         .send(Ok(Some(chat_completion.clone())))
                         .await
                         .is_err()
-                    {
-                        info!(%trace_id, "task completed: client disconnected");
-                        return;
-                    }
+                {
+                    info!(%trace_id, "task completed: client disconnected");
+                    return;
                 }
                 if let Some(usage) = &chat_completion.usage
                     && chat_completion.choices.is_empty()
@@ -403,10 +402,9 @@ async fn process_chat_completion_stream(
                         // Send choice text to detection input channel
                         if let Some(input_tx) =
                             input_txs.as_ref().and_then(|txs| txs.get(&choice.index))
+                            && !choice_text.is_empty()
                         {
-                            if !choice_text.is_empty() {
-                                let _ = input_tx.send(Ok((message_index, choice_text))).await;
-                            }
+                            let _ = input_tx.send(Ok((message_index, choice_text))).await;
                         }
                     } else {
                         debug!(%trace_id, %message_index, ?chat_completion, "chat completion chunk contains no choice");
@@ -555,11 +553,11 @@ fn merge_logprobs(chat_completions: &[ChatCompletionChunk]) -> Option<ChatComple
     let mut content: Vec<ChatCompletionLogprob> = Vec::new();
     let mut refusal: Vec<ChatCompletionLogprob> = Vec::new();
     for chat_completion in chat_completions {
-        if let Some(choice) = chat_completion.choices.first() {
-            if let Some(logprobs) = &choice.logprobs {
-                content.extend_from_slice(&logprobs.content);
-                refusal.extend_from_slice(&logprobs.refusal);
-            }
+        if let Some(choice) = chat_completion.choices.first()
+            && let Some(logprobs) = &choice.logprobs
+        {
+            content.extend_from_slice(&logprobs.content);
+            refusal.extend_from_slice(&logprobs.refusal);
         }
     }
     (!content.is_empty() || !refusal.is_empty())
@@ -589,20 +587,18 @@ async fn process_detection_batch_stream(
                         // If this is the final chat completion chunk with content, send chat completion chunk with finish reason
                         let chat_completions =
                             completion_state.completions.get(&choice_index).unwrap();
-                        if chat_completions.keys().rev().nth(1) == Some(&input_end_index) {
-                            if let Some((_, chat_completion)) = chat_completions.last_key_value() {
-                                if chat_completion
-                                    .choices
-                                    .first()
-                                    .is_some_and(|choice| choice.finish_reason.is_some())
-                                {
-                                    let mut chat_completion = chat_completion.clone();
-                                    // Set role
-                                    chat_completion.choices[0].delta.role = Some(Role::Assistant);
-                                    debug!(%trace_id, %choice_index, ?chat_completion, "sending chat completion chunk with finish reason to response channel");
-                                    let _ = response_tx.send(Ok(Some(chat_completion))).await;
-                                }
-                            }
+                        if chat_completions.keys().rev().nth(1) == Some(&input_end_index)
+                            && let Some((_, chat_completion)) = chat_completions.last_key_value()
+                            && chat_completion
+                                .choices
+                                .first()
+                                .is_some_and(|choice| choice.finish_reason.is_some())
+                        {
+                            let mut chat_completion = chat_completion.clone();
+                            // Set role
+                            chat_completion.choices[0].delta.role = Some(Role::Assistant);
+                            debug!(%trace_id, %choice_index, ?chat_completion, "sending chat completion chunk with finish reason to response channel");
+                            let _ = response_tx.send(Ok(Some(chat_completion))).await;
                         }
                     }
                     Err(error) => {

--- a/src/orchestrator/types/chat_message.rs
+++ b/src/orchestrator/types/chat_message.rs
@@ -33,11 +33,11 @@ pub struct ChatMessage<'a> {
 /// An iterator over chat messages.
 pub trait ChatMessageIterator {
     /// Returns an iterator of [`ChatMessage`]s.
-    fn messages(&self) -> impl Iterator<Item = ChatMessage>;
+    fn messages(&self) -> impl Iterator<Item = ChatMessage<'_>>;
 }
 
 impl ChatMessageIterator for openai::ChatCompletionsRequest {
-    fn messages(&self) -> impl Iterator<Item = ChatMessage> {
+    fn messages(&self) -> impl Iterator<Item = ChatMessage<'_>> {
         self.messages.iter().enumerate().map(|(index, message)| {
             let text = if let Some(openai::Content::Text(text)) = &message.content {
                 Some(text.as_str())
@@ -55,7 +55,7 @@ impl ChatMessageIterator for openai::ChatCompletionsRequest {
 }
 
 impl ChatMessageIterator for openai::ChatCompletion {
-    fn messages(&self) -> impl Iterator<Item = ChatMessage> {
+    fn messages(&self) -> impl Iterator<Item = ChatMessage<'_>> {
         self.choices.iter().map(|choice| ChatMessage {
             index: choice.index,
             role: Some(&choice.message.role),
@@ -66,7 +66,7 @@ impl ChatMessageIterator for openai::ChatCompletion {
 }
 
 impl ChatMessageIterator for openai::ChatCompletionChunk {
-    fn messages(&self) -> impl Iterator<Item = ChatMessage> {
+    fn messages(&self) -> impl Iterator<Item = ChatMessage<'_>> {
         self.choices.iter().map(|choice| ChatMessage {
             index: choice.index,
             role: choice.delta.role.as_ref(),


### PR DESCRIPTION
In this PR:
1. Update Rust version to 1.89.0
2. Apply formatting and linting (new rules usually come out with new Rust releases)
3. Update non-breaking dependencies