### PR TITLE
Add optional rewriting of x-forwarded-access-token header

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -211,6 +211,9 @@ pub struct OrchestratorConfig {
     // List of header keys allowed to be passed to downstream servers
     #[serde(default)]
     pub passthrough_headers: HashSet<String>,
+    // rewrite X-Forwarded-Access-Tokens into Bearer tokens
+    #[serde(default)]
+    pub rewrite_forwarded_access_header: bool,
     /// Number of detector requests to send concurrently for a task.
     #[serde(default = "default_detector_concurrent_requests")]
     pub detector_concurrent_requests: usize,
@@ -416,6 +419,7 @@ impl Default for OrchestratorConfig {
             detectors: HashMap::default(),
             tls: None,
             passthrough_headers: HashSet::default(),
+            rewrite_forwarded_access_header: false,
             detector_concurrent_requests: default_detector_concurrent_requests(),
             chunker_concurrent_requests: default_chunker_concurrent_requests(),
         }


### PR DESCRIPTION
Adds an optional field to the orchestrator config:

- `pub rewrite_forwarded_access_header: bool`

If true, this will then add an additional header processing step after passthrough headers processing, wherein any `x-forwarded-access-token: <token>` header is rewritten into an `authorization: bearer <token>`.

This enables the use of oauth-proxies to authenticate **both** the orchestrator and downstream client servers:
<img width="1661" height="575" alt="image" src="https://github.com/user-attachments/assets/2a4427b4-0934-453d-9caf-d4ae764c7f76" />
