### PR TITLE
Revert DetectorConfig to only support single detector type

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,7 +33,6 @@ detectors:
     # Detector ID/name to be used in user requests
     hap-en:
         # Detector type (text_contents, text_generation, text_chat, text_context_doc)
-        # NOTE: can be a string or a list for multiple detector types.
         type: text_contents
         service:
             hostname: localhost

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,10 +23,7 @@ use std::{
 use serde::Deserialize;
 use tracing::{debug, error, info, warn};
 
-use crate::{
-    clients::{chunker::DEFAULT_CHUNKER_ID, is_valid_hostname},
-    utils::one_or_many,
-};
+use crate::clients::{chunker::DEFAULT_CHUNKER_ID, is_valid_hostname};
 
 /// Default allowed headers to passthrough to clients.
 const DEFAULT_ALLOWED_HEADERS: &[&str] = &[];
@@ -177,8 +174,8 @@ pub struct DetectorConfig {
     /// Default threshold with which to filter detector results by score
     pub default_threshold: f64,
     /// Type of detection this detector performs
-    #[serde(rename = "type", deserialize_with = "one_or_many")]
-    pub r#type: Vec<DetectorType>,
+    #[serde(rename = "type")]
+    pub r#type: DetectorType,
 }
 
 #[derive(Default, Clone, Debug, Deserialize, PartialEq)]


### PR DESCRIPTION
This PR reverts a change merged in #463 to once again only allow a single detector type to be specified for a detector config. This is preferred to avoid detector type ambiguity issues now that we will enable support for multiple detector types on completions and chat completions endpoints.

Leaving `one_or_many` helper in utils in case we need it later.