### PR TITLE
Update CompletionDetections inner types to use Detection, drop Detections type

### DIFF
--- a/src/clients/openai.rs
+++ b/src/clients/openai.rs
@@ -29,14 +29,13 @@ use url::Url;
 
 use super::{
     Client, Error, HttpClient, create_http_client,
-    detector::ContentAnalysisResponse,
     http::{HttpClientExt, RequestBody},
 };
 use crate::{
     config::ServiceConfig,
     health::HealthCheckResult,
     models::{DetectionWarningReason, DetectorParams, ValidationError},
-    orchestrator,
+    orchestrator::{self, types::Detection},
 };
 
 const DEFAULT_PORT: u16 = 8080;
@@ -984,7 +983,7 @@ pub struct CompletionDetections {
 pub struct CompletionInputDetections {
     pub message_index: u32,
     #[serde(default)]
-    pub results: Vec<ContentAnalysisResponse>,
+    pub results: Vec<Detection>,
 }
 
 /// Guardrails completion output detections.
@@ -992,7 +991,7 @@ pub struct CompletionInputDetections {
 pub struct CompletionOutputDetections {
     pub choice_index: u32,
     #[serde(default)]
-    pub results: Vec<ContentAnalysisResponse>,
+    pub results: Vec<Detection>,
 }
 
 /// Guardrails completion detection warning.

--- a/src/orchestrator/common/client.rs
+++ b/src/orchestrator/common/client.rs
@@ -104,14 +104,14 @@ pub async fn detect_text_contents(
     params: DetectorParams,
     chunks: Chunks,
     apply_chunk_offset: bool,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let detector_id = detector_id.clone();
     let contents = chunks
         .iter()
         .map(|chunk| chunk.text.clone())
         .collect::<Vec<_>>();
     if contents.is_empty() {
-        return Ok(Detections::default());
+        return Ok(Vec::new());
     }
     let request = ContentAnalysisRequest::new(contents, params);
     debug!(%detector_id, ?request, "sending detector request");
@@ -141,7 +141,7 @@ pub async fn detect_text_contents(
                 })
                 .collect::<Vec<_>>()
         })
-        .collect::<Detections>();
+        .collect::<Vec<_>>();
     Ok(detections)
 }
 
@@ -154,7 +154,7 @@ pub async fn detect_text_generation(
     params: DetectorParams,
     prompt: String,
     generated_text: String,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let detector_id = detector_id.clone();
     let request = GenerationDetectionRequest::new(prompt, generated_text, params);
     debug!(%detector_id, ?request, "sending detector request");
@@ -173,7 +173,7 @@ pub async fn detect_text_generation(
             detection.detector_id = Some(detector_id.clone());
             detection
         })
-        .collect::<Detections>();
+        .collect::<Vec<Detection>>();
     Ok(detections)
 }
 
@@ -186,7 +186,7 @@ pub async fn detect_text_chat(
     params: DetectorParams,
     messages: Vec<openai::Message>,
     tools: Vec<openai::Tool>,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let detector_id = detector_id.clone();
     let request = ChatDetectionRequest::new(messages, tools, params);
     debug!(%detector_id, ?request, "sending detector request");
@@ -205,7 +205,7 @@ pub async fn detect_text_chat(
             detection.detector_id = Some(detector_id.clone());
             detection
         })
-        .collect::<Detections>();
+        .collect::<Vec<_>>();
     Ok(detections)
 }
 
@@ -219,7 +219,7 @@ pub async fn detect_text_context(
     content: String,
     context_type: ContextType,
     context: Vec<String>,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let detector_id = detector_id.clone();
     let request = ContextDocsDetectionRequest::new(content, context_type, context, params.clone());
     debug!(%detector_id, ?request, "sending detector request");
@@ -238,7 +238,7 @@ pub async fn detect_text_context(
             detection.detector_id = Some(detector_id.clone());
             detection
         })
-        .collect::<Detections>();
+        .collect::<Vec<_>>();
     Ok(detections)
 }
 

--- a/src/orchestrator/common/tasks.rs
+++ b/src/orchestrator/common/tasks.rs
@@ -188,7 +188,7 @@ pub async fn text_contents_detections(
     detectors: HashMap<String, DetectorParams>,
     input_id: u32,
     inputs: Vec<(usize, String)>,
-) -> Result<(u32, Detections), Error> {
+) -> Result<(u32, Vec<Detection>), Error> {
     let chunkers = get_chunker_ids(&ctx, &detectors)?;
     let chunk_map = chunks(ctx.clone(), chunkers, inputs).await?;
     let inputs = detectors
@@ -222,7 +222,7 @@ pub async fn text_contents_detections(
                 .await?
                 .into_iter()
                 .filter(|detection| detection.score >= threshold)
-                .collect::<Detections>();
+                .collect::<Vec<_>>();
                 Ok::<_, Error>(detections)
             }
             .in_current_span()
@@ -230,7 +230,7 @@ pub async fn text_contents_detections(
         .buffer_unordered(ctx.config.detector_concurrent_requests)
         .try_collect::<Vec<_>>()
         .await?;
-    let mut detections = results.into_iter().flatten().collect::<Detections>();
+    let mut detections = results.into_iter().flatten().collect::<Vec<_>>();
     detections.sort_by_key(|detection| detection.start);
     Ok((input_id, detections))
 }
@@ -282,7 +282,7 @@ pub async fn text_contents_detection_streams(
                                     let detections = detections
                                         .into_iter()
                                         .filter(|detection| detection.score >= threshold)
-                                        .collect::<Detections>();
+                                        .collect::<Vec<_>>();
                                     // Send to detection channel
                                     let _ =
                                         detection_tx.send(Ok((input_id, chunk, detections))).await;
@@ -317,7 +317,7 @@ pub async fn text_generation_detections(
     detectors: HashMap<DetectorId, DetectorParams>,
     prompt: String,
     generated_text: String,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let inputs = detectors
         .iter()
         .map(|(detector_id, params)| {
@@ -349,7 +349,7 @@ pub async fn text_generation_detections(
                 .await?
                 .into_iter()
                 .filter(|detection| detection.score >= threshold)
-                .collect::<Detections>();
+                .collect::<Vec<_>>();
                 Ok::<_, Error>(detections)
             }
             .in_current_span()
@@ -357,7 +357,7 @@ pub async fn text_generation_detections(
         .buffer_unordered(ctx.config.detector_concurrent_requests)
         .try_collect::<Vec<_>>()
         .await?;
-    let detections = results.into_iter().flatten().collect::<Detections>();
+    let detections = results.into_iter().flatten().collect::<Vec<_>>();
     Ok(detections)
 }
 
@@ -370,7 +370,7 @@ pub async fn text_chat_detections(
     detectors: HashMap<DetectorId, DetectorParams>,
     messages: Vec<openai::Message>,
     tools: Vec<openai::Tool>,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let inputs = detectors
         .iter()
         .map(|(detector_id, params)| {
@@ -402,7 +402,7 @@ pub async fn text_chat_detections(
                 .await?
                 .into_iter()
                 .filter(|detection| detection.score >= threshold)
-                .collect::<Detections>();
+                .collect::<Vec<_>>();
                 Ok::<_, Error>(detections)
             }
             .in_current_span()
@@ -410,7 +410,7 @@ pub async fn text_chat_detections(
         .buffer_unordered(ctx.config.detector_concurrent_requests)
         .try_collect::<Vec<_>>()
         .await?;
-    let detections = results.into_iter().flatten().collect::<Detections>();
+    let detections = results.into_iter().flatten().collect::<Vec<_>>();
     Ok(detections)
 }
 
@@ -424,7 +424,7 @@ pub async fn text_context_detections(
     content: String,
     context_type: ContextType,
     context: Vec<String>,
-) -> Result<Detections, Error> {
+) -> Result<Vec<Detection>, Error> {
     let inputs = detectors
         .iter()
         .map(|(detector_id, params)| {
@@ -460,7 +460,7 @@ pub async fn text_context_detections(
                     .await?
                     .into_iter()
                     .filter(|detection| detection.score >= threshold)
-                    .collect::<Detections>();
+                    .collect::<Vec<_>>();
                     Ok::<_, Error>(detections)
                 }
                 .in_current_span()
@@ -469,7 +469,7 @@ pub async fn text_context_detections(
         .buffer_unordered(ctx.config.detector_concurrent_requests)
         .try_collect::<Vec<_>>()
         .await?;
-    let detections = results.into_iter().flatten().collect::<Detections>();
+    let detections = results.into_iter().flatten().collect::<Vec<_>>();
     Ok(detections)
 }
 

--- a/src/orchestrator/handlers/chat_completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/streaming.rs
@@ -34,7 +34,7 @@ use crate::{
         common::{self, text_contents_detections, validate_detectors},
         types::{
             ChatCompletionStream, ChatMessageIterator, Chunk, CompletionBatcher, CompletionState,
-            DetectionBatchStream, Detections,
+            Detection, DetectionBatchStream,
         },
     },
 };
@@ -199,7 +199,7 @@ async fn handle_input_detection(
             detections: Some(CompletionDetections {
                 input: vec![CompletionInputDetections {
                     message_index: message.index,
-                    results: detections.into(),
+                    results: detections,
                 }],
                 ..Default::default()
             }),
@@ -476,7 +476,7 @@ async fn handle_whole_doc_output_detection(
         .into_iter()
         .map(|(choice_index, detections)| CompletionOutputDetections {
             choice_index,
-            results: detections.into(),
+            results: detections,
         })
         .collect::<Vec<_>>();
     // Build warnings
@@ -500,7 +500,7 @@ fn output_detection_response(
     completion_state: &Arc<CompletionState<ChatCompletionChunk>>,
     choice_index: u32,
     chunk: Chunk,
-    detections: Detections,
+    detections: Vec<Detection>,
 ) -> Result<ChatCompletionChunk, Error> {
     // Get chat completions for this choice index
     let chat_completions = completion_state.completions.get(&choice_index).unwrap();
@@ -532,7 +532,7 @@ fn output_detection_response(
         chat_completion.detections = Some(CompletionDetections {
             output: vec![CompletionOutputDetections {
                 choice_index,
-                results: detections.into(),
+                results: detections,
             }],
             ..Default::default()
         });

--- a/src/orchestrator/handlers/chat_completions_detection/unary.rs
+++ b/src/orchestrator/handlers/chat_completions_detection/unary.rs
@@ -156,7 +156,7 @@ async fn handle_input_detection(
             detections: Some(CompletionDetections {
                 input: vec![CompletionInputDetections {
                     message_index: message.index,
-                    results: detections.into(),
+                    results: detections,
                 }],
                 ..Default::default()
             }),
@@ -224,7 +224,7 @@ async fn handle_output_detection(
             .filter(|(_, detections)| !detections.is_empty())
             .map(|(input_id, detections)| CompletionOutputDetections {
                 choice_index: input_id,
-                results: detections.into(),
+                results: detections,
             })
             .collect::<Vec<_>>();
         if !output.is_empty() {

--- a/src/orchestrator/handlers/chat_detection.rs
+++ b/src/orchestrator/handlers/chat_detection.rs
@@ -62,7 +62,7 @@ impl Handle<ChatDetectionTask> for Orchestrator {
         .await?;
 
         Ok(ChatDetectionResult {
-            detections: detections.into(),
+            detections: detections.into_iter().map(Into::into).collect(),
         })
     }
 }

--- a/src/orchestrator/handlers/classification_with_gen.rs
+++ b/src/orchestrator/handlers/classification_with_gen.rs
@@ -140,7 +140,7 @@ async fn handle_input_detection(
         let response = ClassifiedGeneratedTextResult {
             input_token_count,
             token_classification_results: TextGenTokenClassificationResults {
-                input: Some(detections.into()),
+                input: Some(detections.into_iter().map(Into::into).collect()),
                 output: None,
             },
             warnings: Some(vec![DetectionWarning::unsuitable_input()]),
@@ -179,7 +179,8 @@ async fn handle_output_detection(
     };
     let mut response = generation;
     if !detections.is_empty() {
-        response.token_classification_results.output = Some(detections.into());
+        response.token_classification_results.output =
+            Some(detections.into_iter().map(Into::into).collect());
         response.warnings = Some(vec![DetectionWarning::unsuitable_output()]);
     }
     info!(%trace_id, "task completed: returning response with output detections");

--- a/src/orchestrator/handlers/completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/completions_detection/streaming.rs
@@ -33,8 +33,8 @@ use crate::{
         Context, Error,
         common::{self, text_contents_detections, validate_detectors},
         types::{
-            Chunk, CompletionBatcher, CompletionState, CompletionStream, DetectionBatchStream,
-            Detections,
+            Chunk, CompletionBatcher, CompletionState, CompletionStream, Detection,
+            DetectionBatchStream,
         },
     },
 };
@@ -182,7 +182,7 @@ async fn handle_input_detection(
             detections: Some(CompletionDetections {
                 input: vec![CompletionInputDetections {
                     message_index: 0,
-                    results: detections.into(),
+                    results: detections,
                 }],
                 ..Default::default()
             }),
@@ -457,7 +457,7 @@ async fn handle_whole_doc_output_detection(
         .into_iter()
         .map(|(choice_index, detections)| CompletionOutputDetections {
             choice_index,
-            results: detections.into(),
+            results: detections,
         })
         .collect::<Vec<_>>();
     // Build warnings
@@ -481,7 +481,7 @@ fn output_detection_response(
     completion_state: &Arc<CompletionState<Completion>>,
     choice_index: u32,
     chunk: Chunk,
-    detections: Detections,
+    detections: Vec<Detection>,
 ) -> Result<Completion, Error> {
     // Get completions for this choice index
     let completions = completion_state.completions.get(&choice_index).unwrap();
@@ -509,7 +509,7 @@ fn output_detection_response(
         completion.detections = Some(CompletionDetections {
             output: vec![CompletionOutputDetections {
                 choice_index,
-                results: detections.into(),
+                results: detections,
             }],
             ..Default::default()
         });

--- a/src/orchestrator/handlers/completions_detection/unary.rs
+++ b/src/orchestrator/handlers/completions_detection/unary.rs
@@ -138,7 +138,7 @@ async fn handle_input_detection(
             detections: Some(CompletionDetections {
                 input: vec![CompletionInputDetections {
                     message_index: 0,
-                    results: detections.into(),
+                    results: detections,
                 }],
                 ..Default::default()
             }),
@@ -199,7 +199,7 @@ async fn handle_output_detection(
             .filter(|(_, detections)| !detections.is_empty())
             .map(|(input_id, detections)| CompletionOutputDetections {
                 choice_index: input_id,
-                results: detections.into(),
+                results: detections,
             })
             .collect::<Vec<_>>();
         if !output.is_empty() {

--- a/src/orchestrator/handlers/context_docs_detection.rs
+++ b/src/orchestrator/handlers/context_docs_detection.rs
@@ -63,7 +63,7 @@ impl Handle<ContextDocsDetectionTask> for Orchestrator {
         .await?;
 
         Ok(ContextDocsResult {
-            detections: detections.into(),
+            detections: detections.into_iter().map(Into::into).collect(),
         })
     }
 }

--- a/src/orchestrator/handlers/detection_on_generation.rs
+++ b/src/orchestrator/handlers/detection_on_generation.rs
@@ -61,7 +61,7 @@ impl Handle<DetectionOnGenerationTask> for Orchestrator {
         .await?;
 
         Ok(DetectionOnGenerationResult {
-            detections: detections.into(),
+            detections: detections.into_iter().map(Into::into).collect(),
         })
     }
 }

--- a/src/orchestrator/handlers/generation_with_detection.rs
+++ b/src/orchestrator/handlers/generation_with_detection.rs
@@ -79,7 +79,7 @@ impl Handle<GenerationWithDetectionTask> for Orchestrator {
         Ok(GenerationWithDetectionResult {
             generated_text,
             input_token_count: generation.input_token_count,
-            detections: detections.into(),
+            detections: detections.into_iter().map(Into::into).collect(),
         })
     }
 }

--- a/src/orchestrator/handlers/streaming_content_detection.rs
+++ b/src/orchestrator/handlers/streaming_content_detection.rs
@@ -185,7 +185,7 @@ async fn process_detection_batch_stream(
                 let response = StreamingContentDetectionResponse {
                     start_index: chunk.start as u32,
                     processed_index: chunk.end as u32,
-                    detections: detections.into(),
+                    detections: detections.into_iter().map(Into::into).collect(),
                 };
                 // Send message to response channel
                 if response_tx.send(Ok(response)).await.is_err() {

--- a/src/orchestrator/handlers/text_content_detection.rs
+++ b/src/orchestrator/handlers/text_content_detection.rs
@@ -61,7 +61,7 @@ impl Handle<TextContentDetectionTask> for Orchestrator {
         .await?;
 
         Ok(TextContentDetectionResult {
-            detections: detections.into(),
+            detections: detections.into_iter().map(Into::into).collect(),
         })
     }
 }

--- a/src/orchestrator/types.rs
+++ b/src/orchestrator/types.rs
@@ -43,7 +43,7 @@ pub type DetectorId = String;
 pub type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 pub type ChunkStream = BoxStream<Result<Chunk, Error>>;
 pub type InputStream = BoxStream<Result<(usize, String), Error>>;
-pub type DetectionStream = BoxStream<Result<(u32, Chunk, Detections), Error>>;
+pub type DetectionStream = BoxStream<Result<(u32, Chunk, Vec<Detection>), Error>>;
 pub type GenerationStream = BoxStream<(usize, Result<ClassifiedGeneratedTextStreamResult, Error>)>;
 pub type ChatCompletionStream = BoxStream<(usize, Result<Option<ChatCompletionChunk>, Error>)>;
 pub type CompletionStream = BoxStream<(usize, Result<Option<Completion>, Error>)>;

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -14,16 +14,23 @@
  limitations under the License.
 
 */
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
 use crate::{clients::detector, models};
 
 /// A detection.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Detection {
     /// Start index of the detection
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<usize>,
     /// End index of the detection
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub end: Option<usize>,
     /// Text corresponding to the detection
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// ID of the detector
     pub detector_id: Option<String>,
@@ -34,29 +41,36 @@ pub struct Detection {
     /// Confidence level of the detection class
     pub score: f64,
     /// Detection evidence
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<DetectionEvidence>,
     /// Detection metadata
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub metadata: models::Metadata,
 }
 
 /// Detection evidence.
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DetectionEvidence {
     /// Evidence name
     pub name: String,
     /// Evidence value
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
     /// Evidence score
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
     /// Additional evidence
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<Evidence>,
 }
 
 /// Additional detection evidence.
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Evidence {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
 }
 

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -41,7 +41,7 @@ pub struct Detection {
     /// Confidence level of the detection class
     pub score: f64,
     /// Detection evidence
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<DetectionEvidence>,
     /// Detection metadata
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -60,7 +60,7 @@ pub struct DetectionEvidence {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
     /// Additional evidence
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<Evidence>,
 }
 

--- a/src/orchestrator/types/detection.rs
+++ b/src/orchestrator/types/detection.rs
@@ -74,55 +74,6 @@ pub struct Evidence {
     pub score: Option<f64>,
 }
 
-/// An array of detections.
-#[derive(Default, Debug, Clone)]
-pub struct Detections(Vec<Detection>);
-
-impl Detections {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl std::ops::Deref for Detections {
-    type Target = Vec<Detection>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Detections {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl IntoIterator for Detections {
-    type Item = Detection;
-    type IntoIter = <Vec<Detection> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl FromIterator<Detection> for Detections {
-    fn from_iter<T: IntoIterator<Item = Detection>>(iter: T) -> Self {
-        let mut detections = Detections::new();
-        for value in iter {
-            detections.push(value);
-        }
-        detections
-    }
-}
-
-impl From<Vec<Detection>> for Detections {
-    fn from(value: Vec<Detection>) -> Self {
-        Self(value)
-    }
-}
-
 // Conversions
 
 impl From<detector::ContentAnalysisResponse> for Detection {
@@ -141,16 +92,6 @@ impl From<detector::ContentAnalysisResponse> for Detection {
                 .unwrap_or_default(),
             metadata: value.metadata,
         }
-    }
-}
-
-impl From<Vec<Vec<detector::ContentAnalysisResponse>>> for Detections {
-    fn from(value: Vec<Vec<detector::ContentAnalysisResponse>>) -> Self {
-        value
-            .into_iter()
-            .flatten()
-            .map(|detection| detection.into())
-            .collect::<Detections>()
     }
 }
 
@@ -235,18 +176,6 @@ impl From<Detection> for models::DetectionResult {
     }
 }
 
-impl From<Detections> for Vec<models::DetectionResult> {
-    fn from(value: Detections) -> Self {
-        value.into_iter().map(Into::into).collect()
-    }
-}
-
-impl From<Vec<models::DetectionResult>> for Detections {
-    fn from(value: Vec<models::DetectionResult>) -> Self {
-        value.into_iter().map(Into::into).collect()
-    }
-}
-
 impl From<Detection> for models::TokenClassificationResult {
     fn from(value: Detection) -> Self {
         Self {
@@ -259,12 +188,6 @@ impl From<Detection> for models::TokenClassificationResult {
             score: value.score,
             token_count: None,
         }
-    }
-}
-
-impl From<Detections> for Vec<models::TokenClassificationResult> {
-    fn from(value: Detections) -> Self {
-        value.into_iter().map(Into::into).collect()
     }
 }
 
@@ -283,11 +206,5 @@ impl From<Detection> for detector::ContentAnalysisResponse {
             evidence,
             metadata: value.metadata,
         }
-    }
-}
-
-impl From<Detections> for Vec<detector::ContentAnalysisResponse> {
-    fn from(value: Detections) -> Self {
-        value.into_iter().map(Into::into).collect()
     }
 }

--- a/src/orchestrator/types/detection_batch_stream.rs
+++ b/src/orchestrator/types/detection_batch_stream.rs
@@ -18,7 +18,7 @@ use futures::{Stream, StreamExt, stream};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error};
 
-use super::{Batch, Chunk, DetectionBatcher, DetectionStream, Detections};
+use super::{Batch, Chunk, Detection, DetectionBatcher, DetectionStream};
 use crate::orchestrator::Error;
 
 /// A stream adapter that wraps detection streams and
@@ -119,7 +119,7 @@ enum DetectionBatcherMessage {
     Push {
         input_id: u32,
         chunk: Chunk,
-        detections: Detections,
+        detections: Vec<Detection>,
     },
     Pop {
         response_tx: oneshot::Sender<Option<Batch>>,
@@ -187,7 +187,7 @@ impl DetectionBatcherManagerHandle {
     }
 
     /// Pushes new detections to the batcher.
-    pub async fn push(&self, input_id: u32, chunk: Chunk, detections: Detections) {
+    pub async fn push(&self, input_id: u32, chunk: Chunk, detections: Vec<Detection>) {
         let _ = self
             .tx
             .send(DetectionBatcherMessage::Push {

--- a/src/orchestrator/types/detection_batcher.rs
+++ b/src/orchestrator/types/detection_batcher.rs
@@ -19,15 +19,15 @@ pub use completion::*;
 pub mod max_processed_index;
 pub use max_processed_index::*;
 
-use super::{Chunk, Detections};
+use super::{Chunk, Detection};
 
-pub type Batch = (u32, Chunk, Detections);
+pub type Batch = (u32, Chunk, Vec<Detection>);
 
 /// A detection batcher.
 /// Implements pluggable batching logic for a [`DetectionBatchStream`].
 pub trait DetectionBatcher: std::fmt::Debug + Clone + Send + 'static {
     /// Pushes new detections.
-    fn push(&mut self, input_id: u32, chunk: Chunk, detections: Detections);
+    fn push(&mut self, input_id: u32, chunk: Chunk, detections: Vec<Detection>);
 
     /// Removes the next batch of detections, if ready.
     fn pop_batch(&mut self) -> Option<Batch>;

--- a/src/orchestrator/types/detection_batcher/completion.rs
+++ b/src/orchestrator/types/detection_batcher/completion.rs
@@ -16,7 +16,7 @@
 */
 use std::collections::{BTreeMap, btree_map};
 
-use super::{Batch, Chunk, DetectionBatcher, Detections};
+use super::{Batch, Chunk, Detection, DetectionBatcher};
 
 pub type ChoiceIndex = u32;
 
@@ -40,7 +40,7 @@ pub struct CompletionBatcher {
     n_detectors: usize,
     // We place the chunk first since chunk ordering includes where
     // the chunk is in all the processed messages.
-    state: BTreeMap<(Chunk, ChoiceIndex), Vec<Detections>>,
+    state: BTreeMap<(Chunk, ChoiceIndex), Vec<Vec<Detection>>>,
 }
 
 impl CompletionBatcher {
@@ -53,7 +53,7 @@ impl CompletionBatcher {
 }
 
 impl DetectionBatcher for CompletionBatcher {
-    fn push(&mut self, choice_index: ChoiceIndex, chunk: Chunk, detections: Detections) {
+    fn push(&mut self, choice_index: ChoiceIndex, chunk: Chunk, detections: Vec<Detection>) {
         match self.state.entry((chunk, choice_index)) {
             btree_map::Entry::Vacant(entry) => {
                 // New chunk, insert entry
@@ -131,8 +131,7 @@ mod test {
                 detection_type: "pii".into(),
                 score: 0.4,
                 ..Default::default()
-            }]
-            .into(),
+            }],
         );
 
         // We only have detections for 1 detector
@@ -160,8 +159,7 @@ mod test {
                     score: 0.8,
                     ..Default::default()
                 },
-            ]
-            .into(),
+            ],
         );
 
         // We have detections for 2 detectors
@@ -210,19 +208,19 @@ mod test {
             batcher.push(
                 choice_index,
                 chunks[1].clone(),
-                Detections::default(), // no detections
+                Vec::new(), // no detections
             );
             // Push chunk-1 detections for hap detector
             batcher.push(
                 choice_index,
                 chunks[0].clone(),
-                Detections::default(), // no detections
+                Vec::new(), // no detections
             );
             // Push chunk-2 detections for hap detector
             batcher.push(
                 choice_index,
                 chunks[1].clone(),
-                Detections::default(), // no detections
+                Vec::new(), // no detections
             );
         }
 
@@ -242,8 +240,7 @@ mod test {
                     detection_type: "pii".into(),
                     score: 0.4,
                     ..Default::default()
-                }]
-                .into(),
+                }],
             );
         }
 
@@ -339,37 +336,37 @@ mod test {
         batcher.push(
             choice_1_index,
             choice_1_chunks[1].clone(),
-            Detections::default(), // no detections
+            Vec::new(), // no detections
         );
         // Same for choice 2
         batcher.push(
             choice_2_index,
             choice_2_chunks[1].clone(),
-            Detections::default(), // no detections
+            Vec::new(), // no detections
         );
         // Push chunk-2 detections for hap detector, choice 2
         batcher.push(
             choice_2_index,
             choice_2_chunks[1].clone(),
-            Detections::default(), // no detections
+            Vec::new(), // no detections
         );
         // Same for choice 1
         batcher.push(
             choice_1_index,
             choice_1_chunks[1].clone(),
-            Detections::default(), // no detections
+            Vec::new(), // no detections
         );
         // Push chunk-1 detections for hap detector, choice 1
         batcher.push(
             choice_1_index,
             choice_1_chunks[0].clone(),
-            Detections::default(), // no detections
+            Vec::new(), // no detections
         );
         // Same for choice 2
         batcher.push(
             choice_2_index,
             choice_2_chunks[0].clone(),
-            Detections::default(), // no detections
+            Vec::new(), // no detections
         );
 
         // We have all detections for chunk-2, but not chunk-1, for both choices
@@ -387,8 +384,7 @@ mod test {
                 detection_type: "pii".into(),
                 score: 0.4,
                 ..Default::default()
-            }]
-            .into(),
+            }],
         );
         // Push chunk-1 detections for pii detector, for second choice
         batcher.push(
@@ -401,8 +397,7 @@ mod test {
                 detection_type: "pii".into(),
                 score: 0.4,
                 ..Default::default()
-            }]
-            .into(),
+            }],
         );
 
         // We have all detections for chunk-1 and chunk-2
@@ -457,10 +452,10 @@ mod test {
 
         // Create detection channels and streams
         let (pii_detections_tx, pii_detections_rx) =
-            mpsc::channel::<Result<(ChoiceIndex, Chunk, Detections), Error>>(4);
+            mpsc::channel::<Result<(ChoiceIndex, Chunk, Vec<Detection>), Error>>(4);
         let pii_detections_stream = ReceiverStream::new(pii_detections_rx).boxed();
         let (hap_detections_tx, hap_detections_rx) =
-            mpsc::channel::<Result<(ChoiceIndex, Chunk, Detections), Error>>(4);
+            mpsc::channel::<Result<(ChoiceIndex, Chunk, Vec<Detection>), Error>>(4);
         let hap_detections_stream = ReceiverStream::new(hap_detections_rx).boxed();
 
         // Create a batcher that will process batches for 2 detectors
@@ -477,7 +472,7 @@ mod test {
                 .send(Ok((
                     choice_index,
                     chunks[1].clone(),
-                    Detections::default(), // no detections
+                    Vec::new(), // no detections
                 )))
                 .await;
 
@@ -486,7 +481,7 @@ mod test {
                 .send(Ok((
                     choice_index,
                     chunks[0].clone(),
-                    Detections::default(), // no detections
+                    Vec::new(), // no detections
                 )))
                 .await;
 
@@ -495,7 +490,7 @@ mod test {
                 .send(Ok((
                     choice_index,
                     chunks[1].clone(),
-                    Detections::default(), // no detections
+                    Vec::new(), // no detections
                 )))
                 .await;
         }
@@ -520,8 +515,7 @@ mod test {
                         detection_type: "pii".into(),
                         score: 0.4,
                         ..Default::default()
-                    }]
-                    .into(),
+                    }],
                 )))
                 .await;
         }

--- a/tests/chat_completions_streaming.rs
+++ b/tests/chat_completions_streaming.rs
@@ -2,7 +2,7 @@ pub mod common;
 use common::orchestrator::*;
 use fms_guardrails_orchestr8::{
     clients::{
-        detector::{ContentAnalysisRequest, ContentAnalysisResponse},
+        detector::ContentAnalysisRequest,
         openai::{
             ChatCompletionChunk, ChatCompletionChunkChoice, ChatCompletionDelta,
             ChatCompletionLogprob, ChatCompletionLogprobs, CompletionDetections,
@@ -11,6 +11,7 @@ use fms_guardrails_orchestr8::{
         },
     },
     models::DetectorParams,
+    orchestrator::types::Detection,
     pb::{
         caikit::runtime::chunkers::{
             BidiStreamingChunkerTokenizationTaskRequest, ChunkerTokenizationTaskRequest,
@@ -427,10 +428,10 @@ async fn input_detectors() -> Result<(), anyhow::Error> {
         Some(CompletionDetections {
             input: vec![CompletionInputDetections {
                 message_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 35,
-                    end: 46,
-                    text: "123-45-6789".into(),
+                results: vec![Detection {
+                    start: Some(35),
+                    end: Some(46),
+                    text: Some("123-45-6789".into()),
                     detection: "NationalNumber.SocialSecurityNumber.US".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -866,10 +867,10 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 5,
-                    end: 19,
-                    text: "(503) 272-8192".into(),
+                results: vec![Detection {
+                    start: Some(5),
+                    end: Some(19),
+                    text: Some("(503) 272-8192".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -903,10 +904,10 @@ async fn output_detectors() -> Result<(), anyhow::Error> {
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 4,
-                    end: 18,
-                    text: "(617) 985-3519".into(),
+                results: vec![Detection {
+                    start: Some(4),
+                    end: Some(18),
+                    text: Some("(617) 985-3519".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -1502,10 +1503,10 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 5,
-                    end: 19,
-                    text: "(503) 272-8192".into(),
+                results: vec![Detection {
+                    start: Some(5),
+                    end: Some(19),
+                    text: Some("(503) 272-8192".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -1548,10 +1549,10 @@ async fn output_detectors_with_logprobs() -> Result<(), anyhow::Error> {
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 4,
-                    end: 18,
-                    text: "(617) 985-3519".into(),
+                results: vec![Detection {
+                    start: Some(4),
+                    end: Some(18),
+                    text: Some("(617) 985-3519".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -2012,10 +2013,10 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 5,
-                    end: 19,
-                    text: "(503) 272-8192".into(),
+                results: vec![Detection {
+                    start: Some(5),
+                    end: Some(19),
+                    text: Some("(503) 272-8192".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -2049,10 +2050,10 @@ async fn output_detectors_with_usage() -> Result<(), anyhow::Error> {
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 4,
-                    end: 18,
-                    text: "(617) 985-3519".into(),
+                results: vec![Detection {
+                    start: Some(4),
+                    end: Some(18),
+                    text: Some("(617) 985-3519".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -2610,10 +2611,10 @@ async fn output_detectors_with_continuous_usage_stats() -> Result<(), anyhow::Er
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 5,
-                    end: 19,
-                    text: "(503) 272-8192".into(),
+                results: vec![Detection {
+                    start: Some(5),
+                    end: Some(19),
+                    text: Some("(503) 272-8192".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -2658,10 +2659,10 @@ async fn output_detectors_with_continuous_usage_stats() -> Result<(), anyhow::Er
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 4,
-                    end: 18,
-                    text: "(617) 985-3519".into(),
+                results: vec![Detection {
+                    start: Some(4),
+                    end: Some(18),
+                    text: Some("(617) 985-3519".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -3753,20 +3754,20 @@ async fn whole_doc_output_detectors() -> Result<(), anyhow::Error> {
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![
-                    ContentAnalysisResponse {
-                        start: 37,
-                        end: 53,
-                        text: "(503) 272-8192\n2".into(),
+                    Detection {
+                        start: Some(37),
+                        end: Some(53),
+                        text: Some("(503) 272-8192\n2".into()),
                         detection: "PhoneNumber".into(),
                         detection_type: "pii".into(),
                         detector_id: Some("pii_detector_whole_doc".into()),
                         score: 0.8,
                         ..Default::default()
                     },
-                    ContentAnalysisResponse {
-                        start: 55,
-                        end: 69,
-                        text: "(617) 985-3519".into(),
+                    Detection {
+                        start: Some(55),
+                        end: Some(69),
+                        text: Some("(617) 985-3519".into()),
                         detection: "PhoneNumber".into(),
                         detection_type: "pii".into(),
                         detector_id: Some("pii_detector_whole_doc".into()),
@@ -4241,10 +4242,10 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 5,
-                    end: 19,
-                    text: "(503) 272-8192".into(),
+                results: vec![Detection {
+                    start: Some(5),
+                    end: Some(19),
+                    text: Some("(503) 272-8192".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -4278,10 +4279,10 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
             input: vec![],
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
-                results: vec![ContentAnalysisResponse {
-                    start: 4,
-                    end: 18,
-                    text: "(617) 985-3519".into(),
+                results: vec![Detection {
+                    start: Some(4),
+                    end: Some(18),
+                    text: Some("(617) 985-3519".into()),
                     detection: "PhoneNumber".into(),
                     detection_type: "pii".into(),
                     detector_id: Some("pii_detector_sentence".into()),
@@ -4309,20 +4310,20 @@ async fn output_detectors_and_whole_doc_output_detectors() -> Result<(), anyhow:
             output: vec![CompletionOutputDetections {
                 choice_index: 0,
                 results: vec![
-                    ContentAnalysisResponse {
-                        start: 37,
-                        end: 53,
-                        text: "(503) 272-8192\n2".into(),
+                    Detection {
+                        start: Some(37),
+                        end: Some(53),
+                        text: Some("(503) 272-8192\n2".into()),
                         detection: "PhoneNumber".into(),
                         detection_type: "pii".into(),
                         detector_id: Some("pii_detector_whole_doc".into()),
                         score: 0.8,
                         ..Default::default()
                     },
-                    ContentAnalysisResponse {
-                        start: 55,
-                        end: 69,
-                        text: "(617) 985-3519".into(),
+                    Detection {
+                        start: Some(55),
+                        end: Some(69),
+                        text: Some("(617) 985-3519".into()),
                         detection: "PhoneNumber".into(),
                         detection_type: "pii".into(),
                         detector_id: Some("pii_detector_whole_doc".into()),

--- a/tests/chat_completions_unary.rs
+++ b/tests/chat_completions_unary.rs
@@ -41,9 +41,9 @@ use fms_guardrails_orchestr8::{
         },
     },
     models::{
-        DetectionWarningReason, DetectorParams, Metadata, UNSUITABLE_INPUT_MESSAGE,
-        UNSUITABLE_OUTPUT_MESSAGE,
+        DetectionWarningReason, DetectorParams, UNSUITABLE_INPUT_MESSAGE, UNSUITABLE_OUTPUT_MESSAGE,
     },
+    orchestrator::types::Detection,
     pb::{
         caikit::runtime::chunkers::ChunkerTokenizationTaskRequest,
         caikit_data_model::nlp::{Token, TokenizationResults},
@@ -483,16 +483,15 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     let mut openai_mocks = MockSet::new();
 
     // Add input detection mock response for input detection
-    let expected_detections = vec![ContentAnalysisResponse {
-        start: 34,
-        end: 42,
-        text: "something".into(),
+    let expected_detections = vec![Detection {
+        start: Some(34),
+        end: Some(42),
+        text: Some("something".into()),
         detection: "has_angle_brackets".into(),
         detection_type: "angle_brackets".into(),
         detector_id: Some(detector_name.into()),
         score: 1.0,
-        evidence: None,
-        metadata: Metadata::new(),
+        ..Default::default()
     }];
 
     let chat_completions_response = ChatCompletion {
@@ -818,16 +817,15 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     let mut chunker_mocks = MockSet::new();
 
     // Add output detection mock response for output detection
-    let expected_detections = vec![ContentAnalysisResponse {
-        start: 28,
-        end: 37,
-        text: "something".into(),
+    let expected_detections = vec![Detection {
+        start: Some(28),
+        end: Some(37),
+        text: Some("something".into()),
         detection: "has_angle_brackets".into(),
         detection_type: "angle_brackets".into(),
         detector_id: Some(detector_name.into()),
         score: 1.0,
-        evidence: None,
-        metadata: Metadata::new(),
+        ..Default::default()
     }];
 
     // Add chat completion choices response for output detection

--- a/tests/completions_detection.rs
+++ b/tests/completions_detection.rs
@@ -32,10 +32,9 @@ use fms_guardrails_orchestr8::{
         },
     },
     models::{
-        DetectionWarningReason, DetectorParams, Metadata, UNSUITABLE_INPUT_MESSAGE,
-        UNSUITABLE_OUTPUT_MESSAGE,
+        DetectionWarningReason, DetectorParams, UNSUITABLE_INPUT_MESSAGE, UNSUITABLE_OUTPUT_MESSAGE,
     },
-    orchestrator::common::current_timestamp,
+    orchestrator::{common::current_timestamp, types::Detection},
     pb::{
         caikit::runtime::chunkers::ChunkerTokenizationTaskRequest,
         caikit_data_model::nlp::{Token, TokenizationResults},
@@ -387,16 +386,15 @@ async fn input_detections() -> Result<(), anyhow::Error> {
     let mut tokenize_mocks = MockSet::new();
 
     // Add input detection mock response for input detection
-    let expected_detections = vec![ContentAnalysisResponse {
-        start: 34,
-        end: 42,
-        text: "something".into(),
+    let expected_detections = vec![Detection {
+        start: Some(34),
+        end: Some(42),
+        text: Some("something".into()),
         detection: "has_angle_brackets".into(),
         detection_type: "angle_brackets".into(),
         detector_id: Some(detector_name.into()),
         score: 1.0,
-        evidence: None,
-        metadata: Metadata::new(),
+        ..Default::default()
     }];
 
     let completions_response = Completion {
@@ -693,16 +691,15 @@ async fn output_detections() -> Result<(), anyhow::Error> {
     let mut chunker_mocks = MockSet::new();
 
     // Add output detection mock response for output detection
-    let expected_detections = vec![ContentAnalysisResponse {
-        start: 28,
-        end: 37,
-        text: "something".into(),
+    let expected_detections = vec![Detection {
+        start: Some(28),
+        end: Some(37),
+        text: Some("something".into()),
         detection: "has_angle_brackets".into(),
         detection_type: "angle_brackets".into(),
         detector_id: Some(detector_name.into()),
         score: 1.0,
-        evidence: None,
-        metadata: Metadata::new(),
+        ..Default::default()
     }];
 
     // Add completion choices response for output detection


### PR DESCRIPTION
This PR applies the following changes in preparation for enabling multiple detector type tasks for completions and chat completions endpoints:

- Implement `Serialize` / `Deserialize` for `Detection`, `Evidence`, and `DetectionEvidence`
  - Serde attributes have been configured to ensure the JSON representation is consistent with `ContentAnalysisResponse`
- Update `CompletionInputDetections` and `CompletionOutputDetections` `results` field type to `Detection`
  - `ContentAnalysisResponse` is only compatible with text contents detections
- Drop `Detections` newtype and replace all usage with `Vec<Detection>` (not required, but feel this newtype isn't needed)
- Update integration tests to reflect changes

**NOTE: Please run functional tests before approving this, if possible**