### PR TITLE
Make clients keep alive interval and timeout configurable

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -297,8 +297,16 @@ pub async fn create_grpc_client<C: Debug + Clone>(
         .connect_timeout(connect_timeout)
         .timeout(request_timeout)
         .keep_alive_while_idle(true)
-        .keep_alive_timeout(Duration::from_secs(DEFAULT_KEEP_ALIVE_TIMEOUT))
-        .http2_keep_alive_interval(Duration::from_secs(DEFAULT_HTTP2_KEEP_ALIVE_INTERVAL))
+        .keep_alive_timeout(Duration::from_secs(
+            service_config
+                .keep_alive_timeout
+                .unwrap_or(DEFAULT_KEEP_ALIVE_TIMEOUT),
+        ))
+        .http2_keep_alive_interval(Duration::from_secs(
+            service_config
+                .http2_keep_alive_interval
+                .unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_INTERVAL),
+        ))
         .resolution_strategy(resolution_strategy);
     let client_tls_config = if let Some(Tls::Config(tls_config)) = &service_config.tls {
         let cert_path = tls_config.cert_path.as_ref().unwrap().as_path();

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,10 @@ pub struct ServiceConfig {
     pub resolution_strategy_timeout: Option<u64>,
     /// Max retries for client calls [currently only for grpc generation]
     pub max_retries: Option<usize>,
+    /// HTTP2 keep-alive interval for client calls [currently only for grpc generation]
+    pub http2_keep_alive_interval: Option<u64>,
+    /// Keep-alive timeout for client calls [currently only for grpc generation]
+    pub keep_alive_timeout: Option<u64>,
 }
 
 impl ServiceConfig {
@@ -95,6 +99,8 @@ impl ServiceConfig {
             resolution_strategy: None,
             resolution_strategy_timeout: None,
             max_retries: None,
+            http2_keep_alive_interval: None,
+            keep_alive_timeout: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,9 +82,9 @@ pub struct ServiceConfig {
     pub resolution_strategy_timeout: Option<u64>,
     /// Max retries for client calls [currently only for grpc generation]
     pub max_retries: Option<usize>,
-    /// HTTP2 keep-alive interval for client calls [currently only for grpc generation]
+    /// HTTP2 keep-alive interval in seconds for client calls [currently only for grpc generation]
     pub http2_keep_alive_interval: Option<u64>,
-    /// Keep-alive timeout for client calls [currently only for grpc generation]
+    /// Keep-alive timeout in seconds for client calls [currently only for grpc generation]
     pub keep_alive_timeout: Option<u64>,
 }
 


### PR DESCRIPTION
This PR makes keep-alive parameters configurable for gRPC clients.