### PR TITLE
Add Cargo.lock to dockerfiles

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -41,7 +41,7 @@ WORKDIR /app
 FROM rust-builder AS fms-guardrails-orchestr8-builder
 ARG CONFIG_FILE=config/config.yaml
 
-COPY build.rs *.toml LICENSE /app/
+COPY build.rs *.toml Cargo.lock LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -50,7 +50,7 @@ RUN rustup component add rustfmt
 FROM rust-builder AS fms-guardrails-orchestr8-builder
 ARG CONFIG_FILE=config/config.yaml
 
-COPY build.rs *.toml LICENSE /app/
+COPY build.rs *.toml Cargo.lock LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -44,7 +44,7 @@ WORKDIR /app
 FROM rust-builder AS fms-guardrails-orchestr8-builder
 ARG CONFIG_FILE=config/config.yaml
 
-COPY build.rs *.toml LICENSE /app/
+COPY build.rs *.toml Cargo.lock LICENSE /app/
 COPY ${CONFIG_FILE} /app/config/config.yaml
 COPY protos/ /app/protos/
 COPY src/ /app/src/


### PR DESCRIPTION
Container image builds were failing because `Cargo.lock` wasn't being added to the build environment. This PR fixes this issue.