### PR TITLE
Adding path prefixes so that llm-d deployments are compatible

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -212,6 +212,14 @@ pub async fn create_http_client(
         .set_port(Some(port))
         .unwrap_or_else(|_| panic!("error setting port: {port}"));
 
+    // Apply path prefix if configured
+    if let Some(prefix) = &service_config.path_prefix {
+        let trimmed = prefix.trim_matches('/');
+        if !trimmed.is_empty() {
+            base_url.set_path(&format!("/{}", trimmed));
+        }
+    }
+
     let connect_timeout = Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SEC);
     let request_timeout = Duration::from_secs(
         service_config

--- a/src/clients/http.rs
+++ b/src/clients/http.rs
@@ -125,6 +125,11 @@ pub struct HttpClient {
 
 impl HttpClient {
     pub fn new(base_url: Url, api_token: Option<String>, inner: HttpClientInner) -> Self {
+        // Ensure base_url has trailing slash for proper path joining
+        let mut base_url = base_url;
+        if !base_url.path().ends_with('/') {
+            base_url.set_path(&format!("{}/", base_url.path()));
+        }
         let health_url = base_url.join("health").unwrap();
         Self {
             base_url,
@@ -139,6 +144,7 @@ impl HttpClient {
     }
 
     pub fn endpoint(&self, path: &str) -> Url {
+        let path = path.trim_start_matches('/');
         self.base_url.join(path).unwrap()
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,8 @@ pub struct ServiceConfig {
     pub hostname: String,
     /// Port for service
     pub port: Option<u16>,
+    /// Path prefix for service endpoints (e.g., "/namespace/service-name")
+    pub path_prefix: Option<String>,
     /// Timeout in seconds for request to be handled
     pub request_timeout: Option<u64>,
     /// TLS provider info
@@ -99,6 +101,7 @@ impl ServiceConfig {
         Self {
             hostname,
             port: Some(port),
+            path_prefix: None,
             request_timeout: None,
             tls: None,
             grpc_dns_probe_interval: None,


### PR DESCRIPTION
## Description

`llm-d` deployments differ from `vllm` ones and are usually of the form:
```
<llm-d-ai-gateway>/<namespace>/<model-name>
```
When configuring the orchestrator with such a model, the current implementation only supports `hostname:port` and doesn't handle path prefixes, making it impossible to connect to llm-d services.
```
Error: invalid hostname: 'openai' has an invalid hostname.
```

To tackle this, I added optional `path_prefix` field to ServiceConfig to support endpoints with path components before the API paths.

## Test plan

Built an image: [quay.io/rh-ee-mmisiura/fms-orchestr8-nlp:path_prefix_4_llmd_v0.1](http://quay.io/rh-ee-mmisiura/fms-orchestr8-nlp:path_prefix_4_llmd_v0.1) and 

- ran the [following demo](https://github.com/m-misiura/guardrails-chunkers/tree/main/demo) with this [orchestrator configuration](https://github.com/m-misiura/guardrails-chunkers/blob/main/demo/orchestrator/orch-gateway-llmd-gateway.yaml)
- ran [this demo](https://github.com/ckavili/rh1-lemon/tree/main/deployment)