### PR TITLE
Router Integration with Selective Detector Support + Streaming Empty Output Fix

### DIFF
--- a/src/clients/detector.rs
+++ b/src/clients/detector.rs
@@ -170,13 +170,23 @@ impl DetectorClient {
         mut headers: HeaderMap,
         request: impl RequestBody,
     ) -> Result<U, Error> {
-        // Check if router is enabled
-        let use_router = self.router_config.as_ref().is_some_and(|r| r.enabled);
+        // Check if router is enabled AND this detector supports routing
+        let use_router = self.router_config.as_ref().is_some_and(|r| {
+            r.enabled
+                && (
+                    // If supported_detectors list is empty, use router for all (backward compatible)
+                    r.supported_detectors.is_empty() ||
+                // Otherwise, only use router if detector is in the supported list
+                r.supported_detectors.iter().any(|d| model_id.contains(d))
+                )
+        });
 
         if use_router {
+            debug!("Using router for detector: {}", model_id);
             self.post_via_router(model_id, url, headers, request).await
         } else {
             // Original direct HTTP path
+            debug!("Using direct HTTP for detector: {}", model_id);
             headers.append(DETECTOR_ID_HEADER_NAME, model_id.parse().unwrap());
             headers.append(CONTENT_TYPE, JSON_CONTENT_TYPE);
             headers.append(MODEL_HEADER_NAME, model_id.parse().unwrap());

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,10 @@ pub struct RouterConfig {
     pub sla_seconds: u64,
     #[serde(default = "default_router_reply_type")]
     pub reply_type: String,
+    /// List of detector model IDs that support routing (have router-receiver sidecars)
+    /// If empty, all detectors will use router when enabled (backward compatible)
+    #[serde(default)]
+    pub supported_detectors: Vec<String>,
 }
 
 fn default_router_hostname() -> String {

--- a/src/orchestrator/handlers/completions_detection/streaming.rs
+++ b/src/orchestrator/handlers/completions_detection/streaming.rs
@@ -120,7 +120,7 @@ pub async fn handle_streaming(
 
             if output_detectors.is_empty() {
                 // No output detectors, forward completion chunks to response channel
-                process_completion_stream(trace_id, completion_stream, None, None, Some(response_tx.clone())).await;
+                process_completion_stream(trace_id, completion_stream, None, None, Some(response_tx.clone()), None).await;
                 info!(%trace_id, "task completed: completion stream closed");
             } else {
                 // Handle output detection
@@ -236,6 +236,7 @@ async fn handle_output_detection(
         });
 
     let completion_state = Arc::new(CompletionState::new());
+    let empty_output_detected = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     if !chunk_detectors.is_empty() {
         // Set up streaming detection pipeline
@@ -280,6 +281,7 @@ async fn handle_output_detection(
             Some(completion_state.clone()),
             Some(input_txs),
             None,
+            Some(empty_output_detected.clone()),
         ));
         // Process detection streams and await completion
         let detection_batch_stream = DetectionBatchStream::new(
@@ -302,13 +304,17 @@ async fn handle_output_detection(
             Some(completion_state.clone()),
             None,
             Some(response_tx.clone()),
+            Some(empty_output_detected.clone()),
         )
         .await;
     }
     // NOTE: at this point, the completions stream has been fully consumed and completion state is final
 
     // If whole doc output detections or usage is requested, a final message is sent with these items
-    if !whole_doc_detectors.is_empty() || completion_state.usage().is_some() {
+    if !whole_doc_detectors.is_empty()
+        || completion_state.usage().is_some()
+        || empty_output_detected.load(std::sync::atomic::Ordering::Relaxed)
+    {
         let mut completion = Completion {
             id: completion_state.id().unwrap().to_string(),
             created: completion_state.created().unwrap(),
@@ -316,6 +322,15 @@ async fn handle_output_detection(
             usage: completion_state.usage().cloned(),
             ..Default::default()
         };
+
+        // Add empty output warning if detected
+        if empty_output_detected.load(std::sync::atomic::Ordering::Relaxed) {
+            completion.warnings.push(CompletionDetectionWarning::new(
+                DetectionWarningReason::EmptyOutput,
+                "One or more choices have no content. Output detection was not executed for those choices",
+            ));
+        }
+
         if !whole_doc_detectors.is_empty() {
             // Handle whole doc detection
             match handle_whole_doc_detection(
@@ -351,7 +366,11 @@ async fn process_completion_stream(
     completion_state: Option<Arc<CompletionState<Completion>>>,
     input_txs: Option<HashMap<u32, mpsc::Sender<Result<(usize, String), Error>>>>,
     response_tx: Option<mpsc::Sender<Result<Option<Completion>, Error>>>,
+    empty_output_detected: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) {
+    // Track which choices have sent data to avoid chunker StopIteration errors
+    let mut choices_with_data = std::collections::HashSet::new();
+
     while let Some((message_index, result)) = completion_stream.next().await {
         match result {
             Ok(Some(completion)) => {
@@ -402,9 +421,16 @@ async fn process_completion_stream(
                         // Send choice text to detection input channel
                         if let Some(input_tx) =
                             input_txs.as_ref().and_then(|txs| txs.get(&choice.index))
-                            && !choice_text.is_empty()
                         {
-                            let _ = input_tx.send(Ok((message_index, choice_text))).await;
+                            if !choice_text.is_empty() {
+                                choices_with_data.insert(choice.index);
+                                let _ = input_tx.send(Ok((message_index, choice_text))).await;
+                            } else if let Some(_finish_reason) = &choice.finish_reason {
+                                // If we have a finish_reason and empty text, mark empty output detected
+                                if let Some(flag) = &empty_output_detected {
+                                    flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                                }
+                            }
                         }
                     } else {
                         debug!(%trace_id, %message_index, ?completion, "completion chunk contains no choice");
@@ -425,6 +451,17 @@ async fn process_completion_stream(
                         let _ = input_tx.send(Err(error.clone())).await;
                     }
                 }
+            }
+        }
+    }
+
+    // After stream completes, send empty string to any input channels that never received data
+    // This prevents chunker StopIteration errors when the model returns empty output
+    if let Some(input_txs) = &input_txs {
+        for (choice_index, input_tx) in input_txs {
+            if !choices_with_data.contains(choice_index) {
+                debug!(%trace_id, %choice_index, "sending empty string to input channel for choice with no data");
+                let _ = input_tx.send(Ok((0, String::new()))).await;
             }
         }
     }

--- a/tests/classification_with_text_gen.rs
+++ b/tests/classification_with_text_gen.rs
@@ -686,6 +686,16 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
             });
         then.internal_server_error();
     });
+    // Add generation text generation mock that returns error
+    generation_mocks.mock(|when, then| {
+        when.path(GENERATION_NLP_UNARY_ENDPOINT)
+            .header(GENERATION_NLP_MODEL_ID_HEADER_NAME, MODEL_ID)
+            .pb(TextGenerationTaskRequest {
+                text: generation_server_error_input.into(),
+                ..Default::default()
+            });
+        then.internal_server_error();
+    });
 
     // Add chunker tokenization mock for detector internal server error scenario
     chunker_mocks.mock(|when, then| {
@@ -718,13 +728,16 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
     let mock_detector_server =
-        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks);
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks.clone());
+    // Create mock server for whole_doc detector as well since the test uses it
+    let mock_detector_whole_doc_server =
+        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_WHOLE_DOC).with_mocks(detector_mocks);
 
     // Run test orchestrator server
     let orchestrator_server = TestOrchestratorServer::builder()
         .config_path(ORCHESTRATOR_CONFIG_FILE_PATH)
         .chunker_servers([&mock_chunker_server])
-        .detector_servers([&mock_detector_server])
+        .detector_servers([&mock_detector_server, &mock_detector_whole_doc_server])
         .generation_server(&mock_generation_server)
         .build()
         .await?;

--- a/tests/classification_with_text_gen.rs
+++ b/tests/classification_with_text_gen.rs
@@ -727,8 +727,8 @@ async fn input_detector_client_error() -> Result<(), anyhow::Error> {
     // Configure mock servers
     let mock_generation_server = MockServer::new_grpc("nlp").with_mocks(generation_mocks);
     let mock_chunker_server = MockServer::new_grpc(CHUNKER_NAME_SENTENCE).with_mocks(chunker_mocks);
-    let mock_detector_server =
-        MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE).with_mocks(detector_mocks.clone());
+    let mock_detector_server = MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_SENTENCE)
+        .with_mocks(detector_mocks.clone());
     // Create mock server for whole_doc detector as well since the test uses it
     let mock_detector_whole_doc_server =
         MockServer::new_http(DETECTOR_NAME_ANGLE_BRACKETS_WHOLE_DOC).with_mocks(detector_mocks);


### PR DESCRIPTION
This PR does below:

1. ConfigMap enhancement for granular control over which detectors use the router service
2. Resolution of chunker failures when models return empty text in streaming mode

